### PR TITLE
Use both touch and mouse events

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,9 +302,14 @@
                 width: this.getDimensions().canvas.width,
                 height: this.getDimensions().canvas.height,
             }
-            attributes[DEVICE_EVENTS['down']] =  this.handleMouseDown;
-            attributes[DEVICE_EVENTS['drag']] =  this.handleDragOver;
-            attributes[DEVICE_EVENTS['drop']] =  this.handleDrop;
+            attributes[DESKTOP_EVENTS['down']] =  this.handleMouseDown;
+            attributes[DESKTOP_EVENTS['drag']] =  this.handleDragOver;
+            attributes[DESKTOP_EVENTS['drop']] =  this.handleDrop;
+            if(TOUCH){
+                attributes[MOBILE_EVENTS['down']] =  this.handleMouseDown;
+                attributes[MOBILE_EVENTS['drag']] =  this.handleDragOver;
+                attributes[MOBILE_EVENTS['drop']] =  this.handleDrop;
+            }
             return React.createElement('canvas', attributes, null);
         }
 


### PR DESCRIPTION
There are devices that with mouse and touch support at the same time. In these cases, it makes sense to track both mouse and touch dragging.