### PR TITLE
Changing names used with browser globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
         module.exports = factory(require('react'), root);
     } else {
         // Browser globals (root is window)
-        root.returnExports = factory(root.React, root);
+        root.AvatarEditor = factory(root.React, root);
     }
 }(this, function (React, global) {
     global = global || window

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
         module.exports = factory(require('react'), root);
     } else {
         // Browser globals (root is window)
-        root.returnExports = factory(root.react, root);
+        root.returnExports = factory(root.React, root);
     }
 }(this, function (React, global) {
     global = global || window


### PR DESCRIPTION
I have an app that exposes modules as global variables (i.e. not a CommonJS environment).

The names used in this module's umd block aren't working. Seems like [line 12](https://github.com/mosch/react-avatar-editor/blob/master/index.js#L12) should change from

```js
root.returnExports = factory(root.react, root);
```

to 

```js
root.AvatarEditor = factory(root.React, root);
```

1. Renamed this module's global to `AvatarEditor` to match the readme examples
2. When exposing itself as a global, react uses the name `React`