### PR TITLE
Add Reactify Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
         "reactjs",
         "react"
     ],
+    "dependencies": {
+        "reactify": "0.17.1"
+    },
     "devDependencies": {
         "react": "0.13.x",
         "http-server": "^0.7.4",
         "watchify": "^3.2.2",
-        "reactify": "0.17.1",
         "uglifyjs": "^2.4.10"
     },
     "browserify": {


### PR DESCRIPTION
You've added Reactify as a transform for Browserify, this means that you need to add it to your dependencies list.
Many people use React with Babel and Reactify.

We had major problems with the web app because of this today. It seems like a breaking change too, so you should bump the major version number when making a change like this.

I've locked down the version number for React-avatar-editor for now to 1.0.0