### PR TITLE
You don't need Reacitify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-avatar-editor",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "description": "Facebook like avatar / profile picture component. Resize and crop your uploaded image using a intutive user interface.",
     "main": "index.es5.js",
     "scripts": {
@@ -41,9 +41,6 @@
         "watchify": "^3.2.2",
         "reactify": "0.17.1",
         "uglifyjs": "^2.4.10"
-    },
-    "browserify": {
-        "transform": [["reactify", { "es6": true }]]
     }
 }
 


### PR DESCRIPTION
Putting Reactify in the transform list breaks Browserify when it can't find it installed. Since you are providing a pre-compiled file and pointing to it, you don't need to put Reactify in the Transform list.