### PR TITLE
Adds support for server-side rendering

### DIFF
--- a/index.es5.js
+++ b/index.es5.js
@@ -2,7 +2,7 @@
 
 var React = require('react');
 
-var isTouchDevice = 'ontouchstart' in window || navigator.msMaxTouchPoints > 0;
+var isTouchDevice = !!(typeof window !== 'undefined' && typeof navigator !== 'undefined' && ('ontouchstart' in window || navigator.msMaxTouchPoints > 0));
 var draggableEvents = {
     mobile: {
         react: {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 var React = require('react');
 
-var isTouchDevice = 'ontouchstart' in window || navigator.msMaxTouchPoints > 0;
+var isTouchDevice =
+    !!(typeof window !== 'undefined' &&
+       typeof navigator !== 'undefined' &&
+       ('ontouchstart' in window || navigator.msMaxTouchPoints > 0)
+      );
 var draggableEvents = {
     mobile: {
         react: {


### PR DESCRIPTION
To accomplish that, we now check for `window` and `navigator` being defined
before referencing them. Without this added step, a ReferenceError is thrown
when used as part of a server-side rendered component.