### PR TITLE
Dont explode on the server-side.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var React = require('react');
 
-var isTouchDevice = 'ontouchstart' in window || navigator.msMaxTouchPoints > 0;
+var isTouchDevice = global.document && ( 'ontouchstart' in global || (global.navigator && global.navigator.msMaxTouchPoints) );
 var draggableEvents = {
     mobile: {
         react: {


### PR DESCRIPTION
This is a regression. I made a PR to fix this earlier and it's broken again.

Please don't assume `window` exists. The alias `global` is always available in both Node and Browserify. Use that to do any check.
Please don't break this again.