### PR TITLE
Replace deprecated method getDOMNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ var AvatarEditor = React.createClass({
     },
 
     componentDidMount() {
-        var context = this.getDOMNode().getContext('2d');
+        var context = React.findDOMNode(this.refs.canvas).getContext('2d');
         if (this.props.image) {
             this.loadImage(this.props.image);
         }
@@ -142,7 +142,7 @@ var AvatarEditor = React.createClass({
     },
 
     componentDidUpdate() {
-        var context = this.getDOMNode().getContext('2d');
+        var context = React.findDOMNode(this.refs.canvas).getContext('2d');
         context.clearRect(0, 0, this.getDimensions().canvas.width, this.getDimensions().canvas.height);
         this.paint(context);
         this.paintImage(context, this.state.image, this.props.border);
@@ -325,7 +325,7 @@ var AvatarEditor = React.createClass({
         attributes[deviceEvents.react.drag] = this.handleDragOver;
         attributes[deviceEvents.react.drop] = this.handleDrop;
 
-        return <canvas {...attributes} />;
+        return <canvas ref='canvas' {...attributes} />;
     }
 });
 


### PR DESCRIPTION
From React's docs: "getDOMNode is deprecated and has been replaced with
React.findDOMNode()."