### PR TITLE
Add borderRadius property for rounded corners

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -61,6 +61,25 @@
     };
     var deviceEvents = isTouchDevice ? draggableEvents.touch : draggableEvents.desktop;
 
+    // Draws a rounded rectangle on a 2D context.
+    var drawRoundedRect = function drawRoundedRect(context, x, y, width, height, borderRadius) {
+        if (borderRadius === 0) {
+            context.rect(x, y, width, height);
+        } else {
+            var widthMinusRad = width - borderRadius;
+            var heightMinusRad = height - borderRadius;
+            context.translate(x, y);
+            context.arc(borderRadius, borderRadius, borderRadius, Math.PI, Math.PI * 1.5);
+            context.lineTo(widthMinusRad, 0);
+            context.arc(widthMinusRad, borderRadius, borderRadius, Math.PI * 1.5, Math.PI * 2);
+            context.lineTo(width, heightMinusRad);
+            context.arc(widthMinusRad, heightMinusRad, borderRadius, Math.PI * 2, Math.PI * 0.5);
+            context.lineTo(borderRadius, height);
+            context.arc(borderRadius, heightMinusRad, borderRadius, Math.PI * 0.5, Math.PI);
+            context.translate(-x, -y);
+        }
+    };
+
     var AvatarEditor = React.createClass({
         displayName: 'AvatarEditor',
 
@@ -290,19 +309,7 @@
             borderRadius = Math.min(borderRadius, width / 2 - borderSize, height / 2 - borderSize);
 
             context.beginPath();
-            // if the radius is zero, gotta worry no mo' : spare some cpu sweat by just drawing a rect
-            if (borderRadius === 0) {
-                context.rect(borderSize, borderSize, width - borderSize * 2, height - borderSize * 2);
-            } else {
-                var sizePlusRad = borderSize + borderRadius;
-                context.arc(sizePlusRad, sizePlusRad, borderRadius, Math.PI, Math.PI * 1.5);
-                context.lineTo(width - sizePlusRad, borderSize);
-                context.arc(width - sizePlusRad, sizePlusRad, borderRadius, Math.PI * 1.5, Math.PI * 2);
-                context.lineTo(width - borderSize, height - sizePlusRad);
-                context.arc(width - sizePlusRad, height - sizePlusRad, borderRadius, Math.PI * 2, Math.PI * 0.5);
-                context.lineTo(sizePlusRad, height - borderSize);
-                context.arc(sizePlusRad, height - sizePlusRad, borderRadius, Math.PI * 0.5, Math.PI);
-            }
+            drawRoundedRect(context, borderSize, borderSize, width - borderSize * 2, height - borderSize * 2, borderRadius); // inner rect, possibly rounded
             context.rect(width, 0, -width, height); // outer rect, drawn "counterclockwise"
             context.fill();
 

--- a/example/app.js
+++ b/example/app.js
@@ -39,11 +39,13 @@ var ImageWithRect = React.createClass({
     }
 });
 
+// Actual app
 var App = React.createClass({
 
     getInitialState: function() {
         return {
             scale: 1,
+            borderRadius: 0,
             preview: null
         };
     },
@@ -59,8 +61,13 @@ var App = React.createClass({
     },
 
     handleScale: function() {
-        var scale = this.refs.scale.value;
+        var scale = parseFloat(this.refs.scale.value);
         this.setState({scale: scale})
+    },
+
+    handleBorderRadius: function() {
+        var borderRadius = parseInt(this.refs.borderRadius.value);
+        this.setState({borderRadius: borderRadius})
     },
 
     logCallback: function(e) {
@@ -71,18 +78,22 @@ var App = React.createClass({
         return <div>
                 <Editor
                     ref="avatar"
-                    scale={parseFloat(this.state.scale)}
-                    onDropFile={this.logCallback.bind(this, 'onDropFile')}
-                    onLoadFailure={this.logCallback.bind(this, 'onLoadFailure')}
-                    onLoadSuccess={this.logCallback.bind(this, 'onLoadSuccess')}
-                    image="example/avatar.jpg" />
+                    scale={this.state.scale}
+                    borderRadius={this.state.borderRadius}
+                    onSave={this.handleSave}
+                    onLoadFailed={this.logCallback.bind(this, 'onLoadFailed')}
+                    onUpload={this.logCallback.bind(this, 'onUpload')}
+                    onImageLoad={this.logCallback.bind(this, 'onImageLoad')}
+                    image="example/avatar.jpg"/>
                 <br />
-                <input name="scale" type="range" ref="scale" onChange={this.handleScale} min="1" max="2" step="0.01" defaultValue="1" />
+                Zoom: <input name="scale" type="range" ref="scale" onChange={this.handleScale} min="1" max="2" step="0.01" defaultValue="1" />
+                <br />
+                Border radius: <input name="scale" type="range" ref="borderRadius" onChange={this.handleBorderRadius} min="0" max="100" step="1" defaultValue="0" />
                 <br />
                 <br />
                 <input type="button" onClick={this.handleSave} value="Preview" />
                 <br />
-                <img src={this.state.preview} />
+                <img src={this.state.preview} style={{borderRadius: this.state.borderRadius + 5 /* because of the 5px padding */}} />
                 
                 {this.state.croppingRect? // display only if there is a cropping rect
                     <ImageWithRect

--- a/example/bundle.js
+++ b/example/bundle.js
@@ -1,7 +1,4 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-<<<<<<< HEAD
-(function(global,factory){if(typeof define==="function"&&define.amd){define(["exports","module"],factory)}else if(typeof exports!=="undefined"&&typeof module!=="undefined"){factory(exports,module)}else{var mod={exports:{}};factory(mod.exports,mod);global.index=mod.exports}})(this,function(exports,module){"use strict";var _extends=Object.assign||function(target){for(var i=1;i<arguments.length;i++){var source=arguments[i];for(var key in source){if(Object.prototype.hasOwnProperty.call(source,key)){target[key]=source[key]}}}return target};var React=require("react");var ReactDOM=require("react-dom");var isTouchDevice=!!(typeof window!=="undefined"&&typeof navigator!=="undefined"&&("ontouchstart"in window||navigator.msMaxTouchPoints>0));var draggableEvents={touch:{react:{down:"onTouchStart",mouseDown:"onMouseDown",drag:"onTouchMove",drop:"onTouchEnd",move:"onTouchMove",mouseMove:"onMouseMove",up:"onTouchEnd",mouseUp:"onMouseUp"},"native":{down:"touchstart",mouseDown:"mousedown",drag:"touchmove",drop:"touchend",move:"touchmove",mouseMove:"mousemove",up:"touchend",mouseUp:"mouseup"}},desktop:{react:{down:"onMouseDown",drag:"onDragOver",drop:"onDrop",move:"onMouseMove",up:"onMouseUp"},"native":{down:"mousedown",drag:"dragStart",drop:"drop",move:"mousemove",up:"mouseup"}}};var deviceEvents=isTouchDevice?draggableEvents.touch:draggableEvents.desktop;var AvatarEditor=React.createClass({displayName:"AvatarEditor",propTypes:{scale:React.PropTypes.number,image:React.PropTypes.string,border:React.PropTypes.number,width:React.PropTypes.number,height:React.PropTypes.number,color:React.PropTypes.arrayOf(React.PropTypes.number),style:React.PropTypes.object,onDropFile:React.PropTypes.func,onLoadFailure:React.PropTypes.func,onLoadSuccess:React.PropTypes.func,onImageReady:React.PropTypes.func},getDefaultProps:function getDefaultProps(){return{scale:1,border:25,width:200,height:200,color:[0,0,0,.5],style:{},onDropFile:function onDropFile(){},onLoadFailure:function onLoadFailure(){},onLoadSuccess:function onLoadSuccess(){},onImageReady:function onImageReady(){}}},getInitialState:function getInitialState(){return{drag:false,my:null,mx:null,image:{x:0,y:0}}},getDimensions:function getDimensions(){return{width:this.props.width,height:this.props.height,border:this.props.border,canvas:{width:this.props.width+this.props.border*2,height:this.props.height+this.props.border*2}}},getImage:function getImage(type,quality){var dom=document.createElement("canvas");var context=dom.getContext("2d");var dimensions=this.getDimensions();var border=0;dom.width=dimensions.width;dom.height=dimensions.height;context.globalCompositeOperation="destination-over";this.paintImage(context,this.state.image,border);return dom.toDataURL(type,quality)},isDataURL:function isDataURL(str){var regex=/^\s*data:([a-z]+\/[a-z]+(;[a-z\-]+\=[a-z\-]+)?)?(;base64)?,[a-z0-9\!\$\&\'\,\(\)\*\+\,\;\=\-\.\_\~\:\@\/\?\%\s]*\s*$/i;return!!str.match(regex)},loadImage:function loadImage(imageURL){var imageObj=new Image;imageObj.onload=this.handleImageReady.bind(this,imageObj);imageObj.onerror=this.props.onLoadFailure;if(!this.isDataURL(imageURL))imageObj.crossOrigin="anonymous";imageObj.src=imageURL},componentDidMount:function componentDidMount(){var context=ReactDOM.findDOMNode(this.refs.canvas).getContext("2d");if(this.props.image){this.loadImage(this.props.image)}this.paint(context);if(document){var nativeEvents=deviceEvents.native;document.addEventListener(nativeEvents.move,this.handleMouseMove,false);document.addEventListener(nativeEvents.up,this.handleMouseUp,false);if(isTouchDevice){document.addEventListener(nativeEvents.mouseMove,this.handleMouseMove,false);document.addEventListener(nativeEvents.mouseUp,this.handleMouseUp,false)}}if(isTouchDevice&&React.initializeTouchEvents)React.initializeTouchEvents(true)},componentWillUnmount:function componentWillUnmount(){if(document){var nativeEvents=deviceEvents.native;document.removeEventListener(nativeEvents.move,this.handleMouseMove,false);document.removeEventListener(nativeEvents.up,this.handleMouseUp,false);if(isTouchDevice){document.removeEventListener(nativeEvents.mouseMove,this.handleMouseMove,false);document.removeEventListener(nativeEvents.mouseUp,this.handleMouseUp,false)}}},componentDidUpdate:function componentDidUpdate(){var context=ReactDOM.findDOMNode(this.refs.canvas).getContext("2d");context.clearRect(0,0,this.getDimensions().canvas.width,this.getDimensions().canvas.height);this.paint(context);this.paintImage(context,this.state.image,this.props.border)},handleImageReady:function handleImageReady(image){var imageState=this.getInitialSize(image.width,image.height);imageState.resource=image;imageState.x=0;imageState.y=0;this.props.onLoadSuccess(imageState);this.setState({drag:false,image:imageState},this.props.onImageReady)},getInitialSize:function getInitialSize(width,height){var newHeight,newWidth,dimensions,canvasRatio,imageRatio;dimensions=this.getDimensions();canvasRatio=dimensions.height/dimensions.width;imageRatio=height/width;if(canvasRatio>imageRatio){newHeight=this.getDimensions().height;newWidth=width*(newHeight/height)}else{newWidth=this.getDimensions().width;newHeight=height*(newWidth/width)}return{height:newHeight,width:newWidth}},componentWillReceiveProps:function componentWillReceiveProps(newProps){if(this.props.image!=newProps.image){this.loadImage(newProps.image)}if(this.props.scale!=newProps.scale||this.props.height!=newProps.height||this.props.width!=newProps.width||this.props.border!=newProps.border){this.squeeze(newProps)}},paintImage:function paintImage(context,image,border){if(image.resource){var position=this.calculatePosition(image,border);context.save();context.globalCompositeOperation="destination-over";context.drawImage(image.resource,position.x,position.y,position.width,position.height);context.restore()}},calculatePosition:function calculatePosition(image,border){image=image||this.state.image;var x,y,width,height,dimensions=this.getDimensions();width=image.width*this.props.scale;height=image.height*this.props.scale;var widthDiff=(width-dimensions.width)/2;var heightDiff=(height-dimensions.height)/2;x=image.x*this.props.scale-widthDiff+border;y=image.y*this.props.scale-heightDiff+border;return{x:x,y:y,height:height,width:width}},paint:function paint(context){context.save();context.translate(0,0);context.fillStyle="rgba("+this.props.color.slice(0,4).join(",")+")";var dimensions=this.getDimensions();var borderSize=dimensions.border;var height=dimensions.canvas.height;var width=dimensions.canvas.width;context.fillRect(0,0,width,borderSize);context.fillRect(0,height-borderSize,width,borderSize);context.fillRect(0,borderSize,borderSize,height-borderSize*2);context.fillRect(width-borderSize,borderSize,borderSize,height-borderSize*2);context.restore()},handleMouseDown:function handleMouseDown(e){var e=e||window.event;e.preventDefault();this.setState({drag:true,mx:null,my:null})},handleMouseUp:function handleMouseUp(){if(this.state.drag){this.setState({drag:false})}},handleMouseMove:function handleMouseMove(e){var e=e||window.event;if(false==this.state.drag){return}var imageState=this.state.image;var lastX=imageState.x;var lastY=imageState.y;var mousePositionX=e.targetTouches?e.targetTouches[0].pageX:e.clientX;var mousePositionY=e.targetTouches?e.targetTouches[0].pageY:e.clientY;var newState={mx:mousePositionX,my:mousePositionY,image:imageState};if(this.state.mx&&this.state.my){var xDiff=(this.state.mx-mousePositionX)/this.props.scale;var yDiff=(this.state.my-mousePositionY)/this.props.scale;imageState.y=this.getBoundedY(lastY-yDiff,this.props.scale);imageState.x=this.getBoundedX(lastX-xDiff,this.props.scale)}this.setState(newState)},squeeze:function squeeze(props){var imageState=this.state.image;imageState.y=this.getBoundedY(imageState.y,props.scale);imageState.x=this.getBoundedX(imageState.x,props.scale);this.setState({image:imageState})},getBoundedX:function getBoundedX(x,scale){var image=this.state.image;var dimensions=this.getDimensions();var widthDiff=Math.floor((image.width-dimensions.width/scale)/2);widthDiff=Math.max(0,widthDiff);return Math.max(-widthDiff,Math.min(x,widthDiff))},getBoundedY:function getBoundedY(y,scale){var image=this.state.image;var dimensions=this.getDimensions();var heightDiff=Math.floor((image.height-dimensions.height/scale)/2);heightDiff=Math.max(0,heightDiff);return Math.max(-heightDiff,Math.min(y,heightDiff))},handleDragOver:function handleDragOver(e){var e=e||window.event;e.preventDefault()},handleDrop:function handleDrop(e){var _this=this;var e=e||window.event;e.stopPropagation();e.preventDefault();if(e.dataTransfer&&e.dataTransfer.files.length){this.props.onDropFile(e);var reader=new FileReader;var file=e.dataTransfer.files[0];reader.onload=function(e){return _this.loadImage(e.target.result)};reader.readAsDataURL(file)}},render:function render(){var defaultStyle={cursor:this.state.drag?"grabbing":"grab"};var attributes={width:this.getDimensions().canvas.width,height:this.getDimensions().canvas.height,style:_extends({},defaultStyle,this.props.style)};attributes[deviceEvents.react.down]=this.handleMouseDown;attributes[deviceEvents.react.drag]=this.handleDragOver;attributes[deviceEvents.react.drop]=this.handleDrop;if(isTouchDevice)attributes[deviceEvents.react.mouseDown]=this.handleMouseDown;return React.createElement("canvas",_extends({ref:"canvas"},attributes))}});module.exports=AvatarEditor});
-=======
 (function (global, factory) {
     if (typeof define === 'function' && define.amd) {
         define(['exports', 'module'], factory);
@@ -72,6 +69,7 @@
             scale: React.PropTypes.number,
             image: React.PropTypes.string,
             border: React.PropTypes.number,
+            borderRadius: React.PropTypes.number,
             width: React.PropTypes.number,
             height: React.PropTypes.number,
             color: React.PropTypes.arrayOf(React.PropTypes.number),
@@ -87,6 +85,7 @@
             return {
                 scale: 1,
                 border: 25,
+                borderRadius: 0,
                 width: 200,
                 height: 200,
                 color: [0, 0, 0, 0.5],
@@ -283,13 +282,30 @@
             var dimensions = this.getDimensions();
 
             var borderSize = dimensions.border;
+            var borderRadius = this.props.borderRadius;
             var height = dimensions.canvas.height;
             var width = dimensions.canvas.width;
 
-            context.fillRect(0, 0, width, borderSize); // top
-            context.fillRect(0, height - borderSize, width, borderSize); // bottom
-            context.fillRect(0, borderSize, borderSize, height - borderSize * 2); // left
-            context.fillRect(width - borderSize, borderSize, borderSize, height - borderSize * 2); // right
+            // clamp border radius between zero (perfect rectangle) and half the size without borders (perfect circle or "pill")
+            borderRadius = Math.max(borderRadius, 0);
+            borderRadius = Math.min(borderRadius, width / 2 - borderSize, height / 2 - borderSize);
+
+            context.beginPath();
+            // if the radius is zero, gotta worry no mo' : spare some cpu sweat by just drawing a rect
+            if (borderRadius === 0) {
+                context.rect(borderSize, borderSize, width - borderSize * 2, height - borderSize * 2);
+            } else {
+                var sizePlusRad = borderSize + borderRadius;
+                context.arc(sizePlusRad, sizePlusRad, borderRadius, Math.PI, Math.PI * 1.5);
+                context.lineTo(width - sizePlusRad, borderSize);
+                context.arc(width - sizePlusRad, sizePlusRad, borderRadius, Math.PI * 1.5, Math.PI * 2);
+                context.lineTo(width - borderSize, height - sizePlusRad);
+                context.arc(width - sizePlusRad, height - sizePlusRad, borderRadius, Math.PI * 2, Math.PI * 0.5);
+                context.lineTo(sizePlusRad, height - borderSize);
+                context.arc(sizePlusRad, height - sizePlusRad, borderRadius, Math.PI * 0.5, Math.PI);
+            }
+            context.rect(width, 0, -width, height); // outer rect, drawn "counterclockwise"
+            context.fill();
 
             context.restore();
         },
@@ -349,6 +365,7 @@
             var image = this.state.image;
             var dimensions = this.getDimensions();
             var widthDiff = Math.floor((image.width - dimensions.width / scale) / 2);
+            widthDiff = Math.max(0, widthDiff);
             return Math.max(-widthDiff, Math.min(x, widthDiff));
         },
 
@@ -356,6 +373,7 @@
             var image = this.state.image;
             var dimensions = this.getDimensions();
             var heightDiff = Math.floor((image.height - dimensions.height / scale) / 2);
+            heightDiff = Math.max(0, heightDiff);
             return Math.max(-heightDiff, Math.min(y, heightDiff));
         },
 
@@ -405,7 +423,6 @@
     module.exports = AvatarEditor;
 });
 
->>>>>>> a81fbaff92a04f26cae334a92273bcd732ad1a1b
 },{"react":159,"react-dom":3}],2:[function(require,module,exports){
 var React = require('react');
 var Editor = require('../dist/index.js');
@@ -448,11 +465,13 @@ var ImageWithRect = React.createClass({displayName: "ImageWithRect",
     }
 });
 
+// Actual app
 var App = React.createClass({displayName: "App",
 
     getInitialState: function() {
         return {
             scale: 1,
+            borderRadius: 0,
             preview: null
         };
     },
@@ -468,8 +487,13 @@ var App = React.createClass({displayName: "App",
     },
 
     handleScale: function() {
-        var scale = this.refs.scale.value;
+        var scale = parseFloat(this.refs.scale.value);
         this.setState({scale: scale})
+    },
+
+    handleBorderRadius: function() {
+        var borderRadius = parseInt(this.refs.borderRadius.value);
+        this.setState({borderRadius: borderRadius})
     },
 
     logCallback: function(e) {
@@ -480,18 +504,22 @@ var App = React.createClass({displayName: "App",
         return React.createElement("div", null, 
                 React.createElement(Editor, {
                     ref: "avatar", 
-                    scale: parseFloat(this.state.scale), 
-                    onDropFile: this.logCallback.bind(this, 'onDropFile'), 
-                    onLoadFailure: this.logCallback.bind(this, 'onLoadFailure'), 
-                    onLoadSuccess: this.logCallback.bind(this, 'onLoadSuccess'), 
+                    scale: this.state.scale, 
+                    borderRadius: this.state.borderRadius, 
+                    onSave: this.handleSave, 
+                    onLoadFailed: this.logCallback.bind(this, 'onLoadFailed'), 
+                    onUpload: this.logCallback.bind(this, 'onUpload'), 
+                    onImageLoad: this.logCallback.bind(this, 'onImageLoad'), 
                     image: "example/avatar.jpg"}), 
                 React.createElement("br", null), 
-                React.createElement("input", {name: "scale", type: "range", ref: "scale", onChange: this.handleScale, min: "1", max: "2", step: "0.01", defaultValue: "1"}), 
+                "Zoom: ", React.createElement("input", {name: "scale", type: "range", ref: "scale", onChange: this.handleScale, min: "1", max: "2", step: "0.01", defaultValue: "1"}), 
+                React.createElement("br", null), 
+                "Border radius: ", React.createElement("input", {name: "scale", type: "range", ref: "borderRadius", onChange: this.handleBorderRadius, min: "0", max: "100", step: "1", defaultValue: "0"}), 
                 React.createElement("br", null), 
                 React.createElement("br", null), 
                 React.createElement("input", {type: "button", onClick: this.handleSave, value: "Preview"}), 
                 React.createElement("br", null), 
-                React.createElement("img", {src: this.state.preview}), 
+                React.createElement("img", {src: this.state.preview, style: {borderRadius: this.state.borderRadius + 5/* because of the 5px padding */}}), 
                 
                 this.state.croppingRect? // display only if there is a cropping rect
                     React.createElement(ImageWithRect, {
@@ -3771,7 +3799,6 @@ var HTMLDOMPropertyConfig = {
     multiple: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     muted: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     name: null,
-    nonce: MUST_USE_ATTRIBUTE,
     noValidate: HAS_BOOLEAN_VALUE,
     open: HAS_BOOLEAN_VALUE,
     optimum: null,
@@ -3783,7 +3810,6 @@ var HTMLDOMPropertyConfig = {
     readOnly: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     rel: null,
     required: HAS_BOOLEAN_VALUE,
-    reversed: HAS_BOOLEAN_VALUE,
     role: MUST_USE_ATTRIBUTE,
     rows: MUST_USE_ATTRIBUTE | HAS_POSITIVE_NUMERIC_VALUE,
     rowSpan: null,
@@ -4229,7 +4255,6 @@ assign(React, {
 });
 
 React.__SECRET_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ReactDOM;
-React.__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = ReactDOMServer;
 
 module.exports = React;
 },{"./Object.assign":25,"./ReactDOM":38,"./ReactDOMServer":48,"./ReactIsomorphic":66,"./deprecated":109}],28:[function(require,module,exports){
@@ -14438,11 +14463,7 @@ module.exports = ReactUpdates;
 
 'use strict';
 
-<<<<<<< HEAD
-module.exports = '0.14.3';
-=======
 module.exports = '0.14.2';
->>>>>>> a81fbaff92a04f26cae334a92273bcd732ad1a1b
 },{}],88:[function(require,module,exports){
 /**
  * Copyright 2013-2015, Facebook, Inc.

--- a/example/bundle.js
+++ b/example/bundle.js
@@ -62,6 +62,25 @@
     };
     var deviceEvents = isTouchDevice ? draggableEvents.touch : draggableEvents.desktop;
 
+    // Draws a rounded rectangle on a 2D context.
+    var drawRoundedRect = function drawRoundedRect(context, x, y, width, height, borderRadius) {
+        if (borderRadius === 0) {
+            context.rect(x, y, width, height);
+        } else {
+            var widthMinusRad = width - borderRadius;
+            var heightMinusRad = height - borderRadius;
+            context.translate(x, y);
+            context.arc(borderRadius, borderRadius, borderRadius, Math.PI, Math.PI * 1.5);
+            context.lineTo(widthMinusRad, 0);
+            context.arc(widthMinusRad, borderRadius, borderRadius, Math.PI * 1.5, Math.PI * 2);
+            context.lineTo(width, heightMinusRad);
+            context.arc(widthMinusRad, heightMinusRad, borderRadius, Math.PI * 2, Math.PI * 0.5);
+            context.lineTo(borderRadius, height);
+            context.arc(borderRadius, heightMinusRad, borderRadius, Math.PI * 0.5, Math.PI);
+            context.translate(-x, -y);
+        }
+    };
+
     var AvatarEditor = React.createClass({
         displayName: 'AvatarEditor',
 
@@ -291,19 +310,7 @@
             borderRadius = Math.min(borderRadius, width / 2 - borderSize, height / 2 - borderSize);
 
             context.beginPath();
-            // if the radius is zero, gotta worry no mo' : spare some cpu sweat by just drawing a rect
-            if (borderRadius === 0) {
-                context.rect(borderSize, borderSize, width - borderSize * 2, height - borderSize * 2);
-            } else {
-                var sizePlusRad = borderSize + borderRadius;
-                context.arc(sizePlusRad, sizePlusRad, borderRadius, Math.PI, Math.PI * 1.5);
-                context.lineTo(width - sizePlusRad, borderSize);
-                context.arc(width - sizePlusRad, sizePlusRad, borderRadius, Math.PI * 1.5, Math.PI * 2);
-                context.lineTo(width - borderSize, height - sizePlusRad);
-                context.arc(width - sizePlusRad, height - sizePlusRad, borderRadius, Math.PI * 2, Math.PI * 0.5);
-                context.lineTo(sizePlusRad, height - borderSize);
-                context.arc(sizePlusRad, height - sizePlusRad, borderRadius, Math.PI * 0.5, Math.PI);
-            }
+            drawRoundedRect(context, borderSize, borderSize, width - borderSize * 2, height - borderSize * 2, borderRadius); // inner rect, possibly rounded
             context.rect(width, 0, -width, height); // outer rect, drawn "counterclockwise"
             context.fill();
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ var AvatarEditor = React.createClass({
         scale: React.PropTypes.number,
         image: React.PropTypes.string,
         border: React.PropTypes.number,
+        borderRadius: React.PropTypes.number,
         width: React.PropTypes.number,
         height: React.PropTypes.number,
         color: React.PropTypes.arrayOf(React.PropTypes.number),
@@ -68,6 +69,7 @@ var AvatarEditor = React.createClass({
         return {
             scale: 1,
             border: 25,
+            borderRadius: 0,
             width: 200,
             height: 200,
             color: [0, 0, 0, 0.5],
@@ -265,13 +267,30 @@ var AvatarEditor = React.createClass({
         var dimensions = this.getDimensions();
 
         var borderSize = dimensions.border;
+        var borderRadius = this.props.borderRadius;
         var height = dimensions.canvas.height;
         var width = dimensions.canvas.width;
-
-        context.fillRect(0, 0, width, borderSize); // top
-        context.fillRect(0, height - borderSize, width, borderSize); // bottom
-        context.fillRect(0, borderSize, borderSize, height - (borderSize * 2)); // left
-        context.fillRect(width - borderSize, borderSize, borderSize, height - (borderSize * 2)); // right
+        
+        // clamp border radius between zero (perfect rectangle) and half the size without borders (perfect circle or "pill")
+        borderRadius = Math.max(borderRadius, 0);
+        borderRadius = Math.min(borderRadius, width/2 - borderSize, height/2 - borderSize);
+        
+        context.beginPath();
+        // if the radius is zero, gotta worry no mo' : spare some cpu sweat by just drawing a rect
+        if (borderRadius === 0) {
+            context.rect(borderSize, borderSize, width - borderSize*2, height - borderSize*2);
+        } else {
+            var sizePlusRad = borderSize + borderRadius;
+            context.arc(sizePlusRad, sizePlusRad, borderRadius, Math.PI, Math.PI*1.5);
+            context.lineTo(width - sizePlusRad, borderSize);
+            context.arc(width - sizePlusRad, sizePlusRad, borderRadius, Math.PI*1.5, Math.PI*2);
+            context.lineTo(width - borderSize, height - sizePlusRad);
+            context.arc(width - sizePlusRad, height - sizePlusRad, borderRadius, Math.PI*2, Math.PI*0.5);
+            context.lineTo(sizePlusRad, height - borderSize);
+            context.arc(sizePlusRad, height - sizePlusRad, borderRadius, Math.PI*0.5, Math.PI);
+        }
+        context.rect(width, 0, -width, height); // outer rect, drawn "counterclockwise"
+        context.fill();
 
         context.restore();
     },

--- a/index.js
+++ b/index.js
@@ -48,6 +48,25 @@ var draggableEvents = {
 };
 var deviceEvents = isTouchDevice ? draggableEvents.touch : draggableEvents.desktop;
 
+// Draws a rounded rectangle on a 2D context.
+var drawRoundedRect = function(context, x, y, width, height, borderRadius) {
+    if (borderRadius === 0) {
+        context.rect(x, y, width, height);
+    } else {
+        var widthMinusRad = width - borderRadius;
+        var heightMinusRad = height - borderRadius;
+        context.translate(x, y);
+        context.arc(borderRadius, borderRadius, borderRadius, Math.PI, Math.PI*1.5);
+        context.lineTo(widthMinusRad, 0);
+        context.arc(widthMinusRad, borderRadius, borderRadius, Math.PI*1.5, Math.PI*2);
+        context.lineTo(width, heightMinusRad);
+        context.arc(widthMinusRad, heightMinusRad, borderRadius, Math.PI*2, Math.PI*0.5);
+        context.lineTo(borderRadius, height);
+        context.arc(borderRadius, heightMinusRad, borderRadius, Math.PI*0.5, Math.PI);
+        context.translate(-x, -y);
+    }
+}
+
 var AvatarEditor = React.createClass({
     propTypes: {
         scale: React.PropTypes.number,
@@ -276,19 +295,7 @@ var AvatarEditor = React.createClass({
         borderRadius = Math.min(borderRadius, width/2 - borderSize, height/2 - borderSize);
         
         context.beginPath();
-        // if the radius is zero, gotta worry no mo' : spare some cpu sweat by just drawing a rect
-        if (borderRadius === 0) {
-            context.rect(borderSize, borderSize, width - borderSize*2, height - borderSize*2);
-        } else {
-            var sizePlusRad = borderSize + borderRadius;
-            context.arc(sizePlusRad, sizePlusRad, borderRadius, Math.PI, Math.PI*1.5);
-            context.lineTo(width - sizePlusRad, borderSize);
-            context.arc(width - sizePlusRad, sizePlusRad, borderRadius, Math.PI*1.5, Math.PI*2);
-            context.lineTo(width - borderSize, height - sizePlusRad);
-            context.arc(width - sizePlusRad, height - sizePlusRad, borderRadius, Math.PI*2, Math.PI*0.5);
-            context.lineTo(sizePlusRad, height - borderSize);
-            context.arc(sizePlusRad, height - sizePlusRad, borderRadius, Math.PI*0.5, Math.PI);
-        }
+        drawRoundedRect(context, borderSize, borderSize, width - borderSize*2, height - borderSize*2, borderRadius); // inner rect, possibly rounded
         context.rect(width, 0, -width, height); // outer rect, drawn "counterclockwise"
         context.fill();
 


### PR DESCRIPTION
Many websites/apps display profile pics with rounded corners.
This feature enables them to give users a more accurate preview of what the final image will look like.

Note that ``getImage()`` still produces a square-cornered image, without erasing the hidden corners.
This should be okay, as the corners are typically rounded on the webpage with CSS ``border-radius``.