### PR TITLE
onMouseMove Support + fix onLoadSuccess bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ module.exports = MyEditor;
 | onLoadSuccess(imgInfo) | function | Invoked when an image (whether passed by props or dropped) load succeeds.
 | onLoadFailure(event)   | function | Invoked when an image (whether passed by props or dropped) load fails.
 | onMouseUp()            | function | Invoked when the user releases their mouse button after interacting with the editor.
+| onMouseMove()          | function | Invoked when the user hold and moving the image.
 
 ## Accessing the resulting image
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -227,8 +227,8 @@
             imageState.resource = image;
             imageState.x = 0;
             imageState.y = 0;
-            this.props.onLoadSuccess(imageState);
             this.setState({ drag: false, image: imageState }, this.props.onImageReady);
+            this.props.onLoadSuccess(imageState);
         },
 
         getInitialSize: function getInitialSize(width, height) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -97,7 +97,8 @@
             onLoadFailure: React.PropTypes.func,
             onLoadSuccess: React.PropTypes.func,
             onImageReady: React.PropTypes.func,
-            onMouseUp: React.PropTypes.func
+            onMouseUp: React.PropTypes.func,
+            onMouseMove: React.PropTypes.func
         },
 
         getDefaultProps: function getDefaultProps() {
@@ -113,7 +114,8 @@
                 onLoadFailure: function onLoadFailure() {},
                 onLoadSuccess: function onLoadSuccess() {},
                 onImageReady: function onImageReady() {},
-                onMouseUp: function onMouseUp() {}
+                onMouseUp: function onMouseUp() {},
+                onMouseMove: function onMouseMove() {}
             };
         },
 
@@ -361,6 +363,7 @@
             }
 
             this.setState(newState);
+            this.props.onMouseMove();
         },
 
         squeeze: function squeeze(props) {

--- a/index.js
+++ b/index.js
@@ -212,8 +212,8 @@ var AvatarEditor = React.createClass({
         imageState.resource = image;
         imageState.x = 0;
         imageState.y = 0;
-        this.props.onLoadSuccess(imageState);
         this.setState({drag: false, image: imageState}, this.props.onImageReady);
+        this.props.onLoadSuccess(imageState);
     },
 
     getInitialSize(width, height) {

--- a/index.js
+++ b/index.js
@@ -82,7 +82,8 @@ var AvatarEditor = React.createClass({
         onLoadFailure: React.PropTypes.func,
         onLoadSuccess: React.PropTypes.func,
         onImageReady: React.PropTypes.func,
-        onMouseUp: React.PropTypes.func
+        onMouseUp: React.PropTypes.func,
+        onMouseMove: React.PropTypes.func
     },
 
     getDefaultProps() {
@@ -98,7 +99,8 @@ var AvatarEditor = React.createClass({
             onLoadFailure() {},
             onLoadSuccess() {},
             onImageReady() {},
-            onMouseUp() {}
+            onMouseUp() {},
+            onMouseMove() {}
         }
     },
 
@@ -141,7 +143,7 @@ var AvatarEditor = React.createClass({
 
         return dom.toDataURL(type, quality);
     },
-    
+
     getCroppingRect() {
         var dim = this.getDimensions();
         var frameRect = {x: dim.border, y: dim.border, width: dim.width, height: dim.height};
@@ -291,11 +293,11 @@ var AvatarEditor = React.createClass({
         var borderRadius = this.props.borderRadius;
         var height = dimensions.canvas.height;
         var width = dimensions.canvas.width;
-        
+
         // clamp border radius between zero (perfect rectangle) and half the size without borders (perfect circle or "pill")
         borderRadius = Math.max(borderRadius, 0);
         borderRadius = Math.min(borderRadius, width/2 - borderSize, height/2 - borderSize);
-        
+
         context.beginPath();
         drawRoundedRect(context, borderSize, borderSize, width - borderSize*2, height - borderSize*2, borderRadius); // inner rect, possibly rounded
         context.rect(width, 0, -width, height); // outer rect, drawn "counterclockwise"
@@ -347,6 +349,7 @@ var AvatarEditor = React.createClass({
         }
 
         this.setState(newState);
+        this.props.onMouseMove();
     },
 
     squeeze(props) {
@@ -381,7 +384,7 @@ var AvatarEditor = React.createClass({
         var e = e || window.event;
         e.stopPropagation();
         e.preventDefault();
-        
+
         if (e.dataTransfer && e.dataTransfer.files.length) {
             this.props.onDropFile(e);
             let reader = new FileReader();
@@ -395,7 +398,7 @@ var AvatarEditor = React.createClass({
         var defaultStyle = {
             cursor: this.state.drag? 'grabbing' : 'grab'
         };
-    
+
         var attributes = {
             width: this.getDimensions().canvas.width,
             height: this.getDimensions().canvas.height,


### PR DESCRIPTION
In this pull request, there are two changes:

- add onMouseMove support to make it closely similar to facebook
- fix onLoadSuccess return NaN values in imageState

