### PR TITLE
getImage() returns a <canvas> instead of data URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ var React = require('react'),
 
 var MyEditor = React.createClass({
   onClickSave: function() {
-    var dataURL = this.refs.editor.getImage();
-    // now save it to the state and set it as <img src="…" /> or send it somewhere else
+    var canvas = this.refs.editor.getImage(); // This is a HTMLCanvasElement.
+    // It can be made into a data URL or a blob, drawn on another canvas, or added to the DOM.
   },
   render: function() {
     return (

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ var AvatarEditor = React.createClass({
         }
     },
     
-    getImage: function getImage(type, quality) {
+    getImage() {
         // get relative coordinates (0 to 1)
         var cropRect = this.getCroppingRect();
         var image = this.state.image;
@@ -146,7 +146,7 @@ var AvatarEditor = React.createClass({
         // the image gets truncated to the size of the canvas.
         canvas.getContext('2d').drawImage(image.resource, -cropRect.x, -cropRect.y);
 
-        return canvas.toDataURL(type, quality);
+        return canvas;
     },
     
     getCroppingRect() {


### PR DESCRIPTION
As I have argued before, ``getImage()`` should return a canvas instead of a data URL, for the sake of simplicity and flexibility.

* Lets us get the dataURL or the blob, draw the canvas ontop of another, display it directly in the DOM, or whatever.
* Renders the two arguments to ``getImage()`` unneeded.
* Calling ``getImage(type, quality)`` is no harder than calling ``getImage().toDataURL(type, quality)``.

