### PR TITLE
Trigger mouse up during drag only

### DIFF
--- a/index.js
+++ b/index.js
@@ -351,8 +351,8 @@ const AvatarEditor = React.createClass({
   handleMouseUp () {
     if (this.state.drag) {
       this.setState({ drag: false })
+      this.props.onMouseUp()
     }
-    this.props.onMouseUp()
   },
 
   handleMouseMove (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-avatar-editor",
-  "version": "4.1.3",
+  "version": "5.0.0",
   "description": "Facebook like avatar / profile picture component. Resize and crop your uploaded image using a intuitive user interface.",
   "main": "dist/index.js",
   "jsnext:main": "index.js",


### PR DESCRIPTION
Noticed that the mouseUp handler is always triggered regardless of whether a drag is in progress.  This gets kinda spammy, and also makes the handler a little bit useless, because it's invoked whenever a mouseup event occurs anywhere on the document, even if the user is not interacting with the avatar editor.