### PR TITLE
Add rotate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export default MyEditor
 | color                  | Number[] | The color of the cropping border, in the form: [red (0-255), green (0-255), blue (0-255), alpha (0.0-1.0)]
 | style                  | Object   | Styles for the canvas element
 | scale                  | Number   | The scale of the image. You can use this to add your own resizing slider.
+| angle                  | Number   | The rotation angle of the image. Possible options are 0, 90, 180, 270 deg
 | onDropFile(event)      | function | Invoked when user drops a file (or more) onto the canvas. Does not perform any further check.
 | onLoadFailure(event)   | function | Invoked when an image (whether passed by props or dropped) load fails.
 | onLoadSuccess(imgInfo) | function | Invoked when an image (whether passed by props or dropped) load succeeds.

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -6,6 +6,7 @@ class App extends React.Component {
   state = {
     scale: 1,
     borderRadius: 0,
+    angle: 0,
     preview: null
   }
 
@@ -15,6 +16,7 @@ class App extends React.Component {
     this.setEditorRef = ::this.setEditorRef
     this.handleSave = ::this.handleSave
     this.handleScale = ::this.handleScale
+    this.handleAngle = ::this.handleAngle
     this.handleBorderRadius = ::this.handleBorderRadius
   }
 
@@ -31,6 +33,11 @@ class App extends React.Component {
   handleScale (e) {
     const scale = parseFloat(e.target.value)
     this.setState({ scale })
+  }
+
+  handleAngle (e) {
+    const angle = parseFloat(e.target.value)
+    this.setState({ angle })
   }
 
   handleBorderRadius (e) {
@@ -52,6 +59,7 @@ class App extends React.Component {
         <ReactAvatarEditor
           ref={this.setEditorRef}
           scale={parseFloat(this.state.scale)}
+          angle={parseFloat(this.state.angle)}
           borderRadius={this.state.borderRadius}
           onSave={this.handleSave}
           onLoadFailure={this.logCallback.bind(this, 'onLoadFailed')}
@@ -83,6 +91,18 @@ class App extends React.Component {
           step="1"
           defaultValue="0"
         />
+        <br />
+        Angle:
+        <input
+          name="angle"
+          type="range"
+          onChange={this.handleAngle}
+          min="0"
+          max="270"
+          step="90"
+          defaultValue="0"
+        />
+
         <br />
         <br />
         <input type="button" onClick={this.handleSave} value="Preview" />

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -36,7 +36,7 @@ class App extends React.Component {
   }
 
   handleAngle (e) {
-    const angle = parseFloat(e.target.value)
+    const angle = e.target.value
     this.setState({ angle })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ class AvatarEditor extends React.Component {
 
   static defaultProps = {
     scale: 1,
+    angle: 0,
     border: 25,
     borderRadius: 0,
     width: 200,
@@ -297,6 +298,9 @@ class AvatarEditor extends React.Component {
     ) {
       this.squeeze(newProps)
     }
+    if (this.props.angle != newProps.angle) {
+      this.rotate((newProps.angle - this.props.angle));
+    }
   }
 
   paintImage (context, image, border) {
@@ -397,6 +401,35 @@ class AvatarEditor extends React.Component {
 
     this.setState(newState)
     this.props.onMouseMove()
+  }
+
+  rotate(angle) {
+    // Normalize angle (only 90/180/270 is allowed)
+    angle %= 360;
+    angle = (angle < 0) ? angle + 360 : angle;
+    angle -= angle % 90;
+    if (!angle) {
+        return;
+    }
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    const imageState = this.state.image;
+    const iWidth = imageState.resource.width;
+    const iHeight = imageState.resource.height
+    canvas.width = iWidth;
+    canvas.height = iHeight;
+    // if 90 or 270 - switch width and height
+    if ((angle % 180) !== 0) {
+        canvas.width = iHeight;
+        canvas.height = iWidth;
+    }
+    context.save();
+    context.translate((canvas.width / 2), (canvas.height / 2));
+    context.rotate((angle * Math.PI / 180));
+    context.translate(-(iWidth / 2), -(iHeight / 2));
+    context.drawImage(imageState.resource, 0, 0);
+    context.restore();
+    this.handleImageReady(canvas);
   }
 
   squeeze (props) {

--- a/src/index.js
+++ b/src/index.js
@@ -420,8 +420,8 @@ class AvatarEditor extends React.Component {
     canvas.height = iHeight;
     // if 90 or 270 - switch width and height
     if ((angle % 180) !== 0) {
-        canvas.width = iHeight;
-        canvas.height = iWidth;
+      canvas.width = iHeight;
+      canvas.height = iWidth;
     }
     context.save();
     context.translate((canvas.width / 2), (canvas.height / 2));

--- a/src/index.js
+++ b/src/index.js
@@ -255,12 +255,17 @@ class AvatarEditor extends React.Component {
     }
   }
 
-  handleImageReady (image) {
+  updateImageState (image, imageReadyCallback = () => {}) {
     const imageState = this.getInitialSize(image.width, image.height)
     imageState.resource = image
     imageState.x = 0
     imageState.y = 0
-    this.setState({ drag: false, image: imageState }, this.props.onImageReady)
+    this.setState({ drag: false, image: imageState }, imageReadyCallback)
+    return imageState;
+  }
+
+  handleImageReady (image) {
+    const imageState = this.updateImageState(image, this.props.onImageReady)
     this.props.onLoadSuccess(imageState)
   }
 
@@ -429,7 +434,7 @@ class AvatarEditor extends React.Component {
     context.translate(-(iWidth / 2), -(iHeight / 2));
     context.drawImage(imageState.resource, 0, 0);
     context.restore();
-    this.handleImageReady(canvas);
+    this.updateImageState(canvas);
   }
 
   squeeze (props) {


### PR DESCRIPTION
This is just reviving the work done by @MykolaPrymak in https://github.com/mosch/react-avatar-editor/pull/49 as I need rotate functionality.

Screencast:

![react-avatar-rotate](https://cloud.githubusercontent.com/assets/38616/22187626/d2548d12-e101-11e6-9b91-9fdad829619c.gif)
