### PR TITLE
Supporting option for Image cross origin 

### DIFF
--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -21952,7 +21952,7 @@
 	      var imageObj = new Image();
 	      imageObj.onload = this.handleImageReady.bind(this, imageObj);
 	      imageObj.onerror = this.props.onLoadFailure;
-	      if (!this.isDataURL(imageURL)) imageObj.crossOrigin = 'anonymous';
+	      if (!this.isDataURL(imageURL) && this.props.crossOrigin) imageObj.crossOrigin = this.props.crossOrigin;
 	      imageObj.src = imageURL;
 	    }
 	  }, {
@@ -22288,6 +22288,7 @@
 	  height: _react2.default.PropTypes.number,
 	  color: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
 	  style: _react2.default.PropTypes.object,
+	  crossOrigin: _react2.default.PropTypes.oneOf(['', 'anonymous', 'use-credentials']),
 
 	  onDropFile: _react2.default.PropTypes.func,
 	  onLoadFailure: _react2.default.PropTypes.func,
@@ -22306,6 +22307,7 @@
 	  height: 200,
 	  color: [0, 0, 0, 0.5],
 	  style: {},
+	  crossOrigin: 'anonymous',
 	  onDropFile: function onDropFile() {},
 	  onLoadFailure: function onLoadFailure() {},
 	  onLoadSuccess: function onLoadSuccess() {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-avatar-editor",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Facebook like avatar / profile picture component. Resize and crop your uploaded image using a intuitive user interface.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,7 @@ class AvatarEditor extends React.Component {
     height: React.PropTypes.number,
     color: React.PropTypes.arrayOf(React.PropTypes.number),
     style: React.PropTypes.object,
+    crossOrigin: React.PropTypes.oneOf(['', 'anonymous', 'use-credentials']),
 
     onDropFile: React.PropTypes.func,
     onLoadFailure: React.PropTypes.func,
@@ -100,6 +101,7 @@ class AvatarEditor extends React.Component {
     height: 200,
     color: [0, 0, 0, 0.5],
     style: {},
+    crossOrigin: 'anonymous',
     onDropFile () {},
     onLoadFailure () {},
     onLoadSuccess () {},
@@ -235,7 +237,7 @@ class AvatarEditor extends React.Component {
     const imageObj = new Image()
     imageObj.onload = this.handleImageReady.bind(this, imageObj)
     imageObj.onerror = this.props.onLoadFailure
-    if (!this.isDataURL(imageURL)) imageObj.crossOrigin = 'anonymous'
+    if (!this.isDataURL(imageURL) && this.props.crossOrigin) imageObj.crossOrigin = this.props.crossOrigin
     imageObj.src = imageURL
   }
 


### PR DESCRIPTION
Based on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin users can select "anonymous" or "use-credentials" for crossorigin attribute of Images

These changes allow users to select the cross-origin value for Images.
default value: "anonymous" for supporting previous versions
valid values: '', 'anonymous' or 'use-credentials'

https://github.com/mosch/react-avatar-editor/issues/142