### PR TITLE
Remove repeated bind of handleMouseMove

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,6 @@ class AvatarEditor extends React.Component {
     this.handleMouseMove = ::this.handleMouseMove
     this.handleMouseDown = ::this.handleMouseDown
     this.handleMouseUp = ::this.handleMouseUp
-    this.handleMouseMove = ::this.handleMouseMove
     this.handleDragOver = ::this.handleDragOver
     this.handleDrop = ::this.handleDrop
   }


### PR DESCRIPTION
Little cleanup - noticed that handleMouseMove is bound to `this` twice in the constructor. :)