### PR TITLE
Add ability to control position of cropping area via prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ class MyEditor extends React.Component {
         border={50}
         color={[255, 255, 255, 0.6]} // RGBA
         scale={1.2}
+        position={{x:0.5, y:0.25}}
         rotate={0}
       />
     )
@@ -47,6 +48,7 @@ export default MyEditor
 | color                  | Number[] | The color of the cropping border, in the form: [red (0-255), green (0-255), blue (0-255), alpha (0.0-1.0)]
 | style                  | Object   | Styles for the canvas element
 | scale                  | Number   | The scale of the image. You can use this to add your own resizing slider.
+| position               | Object   | The x and y co-ordinates (in the range 0 to 1) of the center of the cropping area of the image.  Note that if you set this prop, you will need to keep it up to date via onPositionChange in order for panning to continue working.
 | rotate                 | Number   | The rotation degree of the image. You can use this to rotate image (e.g 90, 270 degrees).
 | onDropFile(event)      | function | Invoked when user drops a file (or more) onto the canvas. Does not perform any further check.
 | onLoadFailure(event)   | function | Invoked when an image (whether passed by props or dropped) load fails.
@@ -55,6 +57,7 @@ export default MyEditor
 | onMouseUp()            | function | Invoked when the user releases their mouse button after interacting with the editor.
 | onMouseMove()          | function | Invoked when the user hold and moving the image.
 | onImageChange()        | function | Invoked when the user changed the image. Not invoked on the first render, and invoked multiple times during drag, etc.
+| onPositionChange()     | function | Invoked when the user pans the editor to change the selected area of the image.  Passed a position object in the form `{ x: 0.5, y: 0.5 }` where x and y are the relative x and y coordinates of the center of the selected area.
 
 ## Accessing the resulting image
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,10 @@ class AvatarEditor extends React.Component {
     borderRadius: React.PropTypes.number,
     width: React.PropTypes.number,
     height: React.PropTypes.number,
+    position: React.PropTypes.shape({
+        x: React.PropTypes.number,
+        y: React.PropTypes.number
+    }),
     color: React.PropTypes.arrayOf(React.PropTypes.number),
     style: React.PropTypes.object,
     crossOrigin: React.PropTypes.oneOf(['', 'anonymous', 'use-credentials']),
@@ -89,7 +93,8 @@ class AvatarEditor extends React.Component {
     onImageReady: React.PropTypes.func,
     onImageChange: React.PropTypes.func,
     onMouseUp: React.PropTypes.func,
-    onMouseMove: React.PropTypes.func
+    onMouseMove: React.PropTypes.func,
+    onPositionChange: React.PropTypes.func
   }
 
   static defaultProps = {
@@ -108,7 +113,8 @@ class AvatarEditor extends React.Component {
     onImageReady () {},
     onImageChange () {},
     onMouseUp () {},
-    onMouseMove () {}
+    onMouseMove () {},
+    onPositionChange () {}
   }
 
   constructor (props) {
@@ -128,8 +134,8 @@ class AvatarEditor extends React.Component {
     my: null,
     mx: null,
     image: {
-      x: 0,
-      y: 0
+      x: 0.5,
+      y: 0.5
     }
   }
 
@@ -206,22 +212,36 @@ class AvatarEditor extends React.Component {
     return canvas
   }
 
+  getXScale() {
+    let canvasAspect = this.props.width / this.props.height
+    let imageAspect = this.state.image.width / this.state.image.height
+
+    return Math.min(1, canvasAspect / imageAspect)
+  }
+
+  getYScale() {
+    let canvasAspect = this.props.height / this.props.width
+    let imageAspect = this.state.image.height / this.state.image.width
+
+    return Math.min(1, canvasAspect / imageAspect)
+  }
+
   getCroppingRect () {
-    const dim = this.getDimensions()
+    let position = this.props.position || { x: this.state.image.x, y: this.state.image.y },
+        width = (1 / this.props.scale) * this.getXScale(),
+        height = (1 / this.props.scale) * this.getYScale()
 
-    const frameRect = {
-      x: dim.border,
-      y: dim.border,
-      width: dim.width,
-      height: dim.height
-    }
+    let croppingRect = {
+      x: position.x - (width / 2),
+      y: position.y - (height / 2),
+      width,
+      height
+    };
 
-    const imageRect = this.calculatePosition(this.state.image, dim.border)
     return {
-      x: (frameRect.x - imageRect.x) / imageRect.width,
-      y: (frameRect.y - imageRect.y) / imageRect.height,
-      width: frameRect.width / imageRect.width,
-      height: frameRect.height / imageRect.height
+      ...croppingRect,
+      x: Math.max(0, Math.min(croppingRect.x, 1 - croppingRect.width)),
+      y: Math.max(0, Math.min(croppingRect.y, 1 - croppingRect.height))
     }
   }
 
@@ -277,6 +297,7 @@ class AvatarEditor extends React.Component {
     this.paintImage(context, this.state.image, this.props.border)
 
     if (prevProps.image !== this.props.image ||
+        prevProps.position !== this.props.position ||
         prevProps.scale !== this.props.scale ||
         prevProps.rotate !== this.props.rotate ||
         prevState.my !== this.state.my ||
@@ -290,8 +311,8 @@ class AvatarEditor extends React.Component {
   handleImageReady (image) {
     const imageState = this.getInitialSize(image.width, image.height)
     imageState.resource = image
-    imageState.x = 0
-    imageState.y = 0
+    imageState.x = 0.5;
+    imageState.y = 0.5;
     this.setState({ drag: false, image: imageState }, this.props.onImageReady)
     this.props.onLoadSuccess(imageState)
   }
@@ -322,14 +343,6 @@ class AvatarEditor extends React.Component {
     if (newProps.image && this.props.image !== newProps.image) {
       this.loadImage(newProps.image)
     }
-    if (
-      this.props.scale !== newProps.scale ||
-      this.props.height !== newProps.height ||
-      this.props.width !== newProps.width ||
-      this.props.border !== newProps.border
-    ) {
-      this.squeeze(newProps)
-    }
   }
 
   paintImage (context, image, border) {
@@ -351,15 +364,14 @@ class AvatarEditor extends React.Component {
 
   calculatePosition (image, border) {
     image = image || this.state.image
-    const dimensions = this.getDimensions()
+
+    const croppingRect = this.getCroppingRect()
 
     const width = image.width * this.props.scale
     const height = image.height * this.props.scale
 
-    const widthDiff = (width - dimensions.width) / 2
-    const heightDiff = (height - dimensions.height) / 2
-    const x = image.x * this.props.scale - widthDiff + border
-    const y = image.y * this.props.scale - heightDiff + border
+    const x = border - (croppingRect.x * width)
+    const y = border - (croppingRect.y * height)
 
     return {
       x,
@@ -418,18 +430,12 @@ class AvatarEditor extends React.Component {
       return
     }
 
-    const imageState = this.state.image
-
-    const lastX = imageState.x
-    const lastY = imageState.y
-
     const mousePositionX = e.targetTouches ? e.targetTouches[0].pageX : e.clientX
     const mousePositionY = e.targetTouches ? e.targetTouches[0].pageY : e.clientY
 
     const newState = {
       mx: mousePositionX,
-      my: mousePositionY,
-      image: imageState
+      my: mousePositionY
     }
 
     let rotate = this.props.rotate
@@ -438,70 +444,66 @@ class AvatarEditor extends React.Component {
     rotate = (rotate < 0) ? rotate + 360 : rotate
     rotate -= rotate % 90
 
-    const isPortrait = imageState.height > imageState.width
-
     if (this.state.mx && this.state.my) {
       const mx = this.state.mx - mousePositionX
       const my = this.state.my - mousePositionY
 
-      const xDiff = (rotate === 0 || rotate === 180 ? mx : my) / this.props.scale
-      const yDiff = (rotate === 0 || rotate === 180 ? my : mx) / this.props.scale
+      const width = this.state.image.width * this.props.scale
+      const height = this.state.image.height * this.props.scale
+
+      let {
+        x: lastX,
+        y: lastY
+      } = this.getCroppingRect()
+
+      lastX *= width
+      lastY *= height
+
+      const xDiff = (rotate === 0 || rotate === 180 ? mx : my)
+      const yDiff = (rotate === 0 || rotate === 180 ? my : mx)
 
       let y
       let x
 
       if (rotate === 0) {
-        y = lastY - yDiff
-        x = lastX - xDiff
+        y = lastY + yDiff
+        x = lastX + xDiff
       }
 
       if (rotate === 90) {
-        y = lastY + yDiff
-        x = lastX - xDiff
-      }
-
-      if (rotate === 180) {
-        y = lastY + yDiff
-        x = lastX + xDiff
-      }
-
-      if (rotate === 270) {
         y = lastY - yDiff
         x = lastX + xDiff
       }
 
-      imageState.y = this.getBoundedY(y, this.props.scale)
-      imageState.x = this.getBoundedX(x, this.props.scale)
+      if (rotate === 180) {
+        y = lastY - yDiff
+        x = lastX - xDiff
+      }
+
+      if (rotate === 270) {
+        y = lastY + yDiff
+        x = lastX - xDiff
+      }
+
+      let relativeWidth = (1 / this.props.scale) * this.getXScale()
+      let relativeHeight = (1 / this.props.scale) * this.getYScale()
+
+      const position = {
+          x: (x / width) + (relativeWidth / 2),
+          y: (y / height) + (relativeHeight / 2)
+      }
+
+      this.props.onPositionChange(position)
+
+      newState.image = {
+        ...this.state.image,
+        ...position
+      }
     }
 
     this.setState(newState)
+
     this.props.onMouseMove()
-  }
-
-  squeeze (props) {
-    let imageState = this.state.image
-    imageState.y = this.getBoundedY(imageState.y, props.scale)
-    imageState.x = this.getBoundedX(imageState.x, props.scale)
-    this.setState({ image: imageState })
-  }
-
-  getBoundedX (x, scale) {
-    const image = this.state.image
-
-    const dimensions = this.getDimensions()
-    let widthDiff = Math.floor((image.width - dimensions.width / scale) / 2)
-    widthDiff = Math.max(0, widthDiff)
-
-    return Math.max(-widthDiff, Math.min(x, widthDiff))
-  }
-
-  getBoundedY (y, scale) {
-    const image = this.state.image
-    const dimensions = this.getDimensions()
-    let heightDiff = Math.floor((image.height - dimensions.height / scale) / 2)
-    heightDiff = Math.max(0, heightDiff)
-
-    return Math.max(-heightDiff, Math.min(y, heightDiff))
   }
 
   handleDragOver (e) {


### PR DESCRIPTION
Hey @mosch!  Thanks for working on this project, I hope we can work together to get this additional functionality into the codebase. :D

In order to achieve this functionality I was initially looking at allowing the user to pass a croppingRect instead of a scale prop and using that to set the scale and the position of the cropped area.  However that approach has a couple of problems:
1. It means the consumer of the component has to do non-trivial math to keep the x and y coordinates in the cropping rect consistent with the width and height as the scale is adjusted.
1. It makes the API more complex - we would have to decide order of precedence between the scale prop and the croppingRect prop, and document this behaviour.

Instead, I went with the approach of adding a new prop which can live alongside the scale prop and work in concert with it:
* Added a new prop `position` which overrides the internal state holding the selected area, to allow consumers of this component to restore a previously-saved cropping area when rendering this component.
* New prop overrides internal state, but if it's not supplied the state continues to be used, so this new feature is totally optional :)
* The position is specified as relative x and y coordinates which are interpreted as the center of the cropping area.  By making them center coordinates, we avoid changing the scaling behaviour - as you scale an image where the position is (0.5,0.5), the image stays centered on the same point.  If we used top-left it would scale from the top left (gross).
* In order to keep the internal code as simple as possible, I changed the way the cropping area position is stored internally to match the format of the position prop.  I also moved the capping of the x and y coordinates to the getCroppingRect function, so that we can always be sure that the x and y coordinates we're using don't cause part of the cropping rect to fall outside the image bounds.