### PR TITLE
Make border radius in demo preview consistent with component

### DIFF
--- a/docs/App.jsx
+++ b/docs/App.jsx
@@ -109,7 +109,7 @@ class App extends React.Component {
         <br />
         <img
           src={this.state.preview}
-          style={{ borderRadius: `${this.state.borderRadius / 2}%` }}
+          style={{ borderRadius: `${Math.min(this.state.height, this.state.width) * ((this.state.borderRadius / 2) / 100)}px` }}
         />
 
         {this.state.croppingRect ? // display only if there is a cropping rect


### PR DESCRIPTION
Previously for non-square sizes, the preview was rendering an elliptical shape instead of a pill shape, because the border radius was specified as a percentage.  This commit changes the styling to use a pixel border radius to get the appropriate pill shape.

**Before**

<img width="353" alt="screen shot 2017-02-16 at 11 09 22" src="https://cloud.githubusercontent.com/assets/542836/23019137/c0888828-f438-11e6-82be-ce4a44348670.png">

**After**

<img width="344" alt="screen shot 2017-02-16 at 11 09 43" src="https://cloud.githubusercontent.com/assets/542836/23019142/c4b45bc0-f438-11e6-883f-8ec70e5a1c07.png">
