### PR TITLE
Handle scale < 1

### DIFF
--- a/docs/App.jsx
+++ b/docs/App.jsx
@@ -18,8 +18,14 @@ class App extends React.Component {
     const rect = this.editor.getCroppingRect()
 
     this.setState({
-      preview: img,
-      croppingRect: rect
+      preview: {
+        img,
+        rect,
+        scale: this.state.scale,
+        width: this.state.width,
+        height: this.state.height,
+        borderRadius: this.state.borderRadius
+      }
     })
   }
 
@@ -175,21 +181,22 @@ class App extends React.Component {
         <br />
         <input type="button" onClick={this.handleSave} value="Preview" />
         <br />
-        <img
-          src={this.state.preview}
-          style={{ borderRadius: `${(Math.min(this.state.height, this.state.width) + 10) * ((this.state.borderRadius / 2) / 100)}px` }}
-        />
+        { !!this.state.preview &&
+          <img
+            src={this.state.preview.img}
+            style={{ borderRadius: `${(Math.min(this.state.preview.height, this.state.preview.width) + 10) * ((this.state.preview.borderRadius / 2) / 100)}px` }}
+          />
+        }
 
-        {this.state.croppingRect ? // display only if there is a cropping rect
+        { !!this.state.preview &&
           <ImageWithRect
-            width={200 * 478 / 270}
-            height={200}
+            width={this.state.preview.scale < 1 ? this.state.preview.width : (this.state.preview.height * 478 / 270)}
+            height={this.state.preview.height}
             image="avatar.jpg"
-            rect={this.state.croppingRect}
+            rect={this.state.preview.rect}
             style={{margin: '10px 24px 32px', padding: 5, border: '1px solid #CCC'}}
           />
-          :
-          null}
+        }
       </div>
     )
   }
@@ -220,16 +227,38 @@ class ImageWithRect extends React.Component {
     const ctx = this.canvas.getContext('2d')
     const { image, rect, width, height} = this.props
 
-    ctx.drawImage(this.imgElement, 0, 0, width, height)
+    ctx.clearRect(0, 0, width, height)
 
-    if (rect) {
-      ctx.strokeStyle = 'red'
-      ctx.strokeRect(
-        Math.round(rect.x * width) + 0.5,
-        Math.round(rect.y * height) + 0.5,
-        Math.round(rect.width * width),
-        Math.round(rect.height * height)
+    ctx.strokeStyle = 'red'
+
+    if (rect && (rect.width > 1 || rect.height > 1)) {
+      ctx.drawImage(
+        this.imgElement,
+        Math.round(-rect.x * (width / rect.width)),
+        Math.round(-rect.y * (height / rect.height)),
+        Math.round(width / rect.width),
+        Math.round(height / rect.height)
       )
+
+      if (rect) {
+        ctx.strokeRect(
+          1,
+          1,
+          Math.round(width) - 2,
+          Math.round(height) - 2
+        )
+      }
+    } else {
+      ctx.drawImage(this.imgElement, 0, 0, width, height)
+
+      if (rect) {
+        ctx.strokeRect(
+          Math.round(rect.x * width) + 0.5,
+          Math.round(rect.y * height) + 0.5,
+          Math.round(rect.width * width),
+          Math.round(rect.height * height)
+        )
+      }
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -256,10 +256,27 @@ class AvatarEditor extends React.Component {
       height
     };
 
+    let xMin = 0,
+      xMax = 1 - croppingRect.width,
+      yMin = 0,
+      yMax = 1 - croppingRect.height
+
+    // If the cropping rect is larger than the image, then we need to change
+    // our maxima & minima for x & y to allow the image to appear anywhere up
+    // to the very edge of the cropping rect.
+    let isLargerThanImage = width > 1 || height > 1
+
+    if (isLargerThanImage) {
+      xMin = -croppingRect.width
+      xMax = 1
+      yMin = -croppingRect.height
+      yMax = 1
+    }
+
     return {
       ...croppingRect,
-      x: Math.max(0, Math.min(croppingRect.x, 1 - croppingRect.width)),
-      y: Math.max(0, Math.min(croppingRect.y, 1 - croppingRect.height))
+      x: Math.max(xMin, Math.min(croppingRect.x, xMax)),
+      y: Math.max(yMin, Math.min(croppingRect.y, yMax))
     }
   }
 


### PR DESCRIPTION
### Component Changes
* Previously the max/min of the x & y values in the cropping rect were calculated based on the assumption that scale >= 1, and that you wouldn't want any whitespace in your resultant image.
* Now, if scale >= 1, the bounds are the same as they were before, but if scale < 1, you can drag the image anywhere within the editor view (all the way to immediately outside the visible area).
* As the incorrect scaling behaviour described in #150 was caused by the max/min for x & y being calculated correctly when scale < 1, this fixes #150.

### Demo Changes
* Update `ImageWithRect` component so that it works when scale < 1 - in this situation, the cropping rect fills the canvas and the image is rendered inside it.  We could go further here - in this situation we don't show the part of the image that's outside the cropping rect, but I don't have more time to work on this this morning, so that will have to be left as a future improvement.
* Store scale, width, height, and borderRadius when preview is saved.  Previously when the preview button was pressed, the image and cropping rect were updated for the preview, but the other values affecting the preview were not - they were retrieved directly.  Now it's all saved into the preview property of the state, so the preview no longer updates in any way until you press the button again.