### PR TITLE
Remove default crossOrigin prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ export default MyEditor
 | scale                  | Number   | The scale of the image. You can use this to add your own resizing slider.
 | position               | Object   | The x and y co-ordinates (in the range 0 to 1) of the center of the cropping area of the image.  Note that if you set this prop, you will need to keep it up to date via onPositionChange in order for panning to continue working.
 | rotate                 | Number   | The rotation degree of the image. You can use this to rotate image (e.g 90, 270 degrees).
+| crossOrigin            | String   | The value to use for the crossOrigin property of the image, if loaded from a non-data URL.  Valid values are `"anonymous"` and `"use-credentials"`.  See [this page](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for more information.
 | onDropFile(event)      | function | Invoked when user drops a file (or more) onto the canvas. Does not perform any further check.
 | onLoadFailure(event)   | function | Invoked when an image (whether passed by props or dropped) load fails.
 | onLoadSuccess(imgInfo) | function | Invoked when an image (whether passed by props or dropped) load succeeds.

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,6 @@ class AvatarEditor extends React.Component {
     height: 200,
     color: [0, 0, 0, 0.5],
     style: {},
-    crossOrigin: 'anonymous',
     onDropFile () {},
     onLoadFailure () {},
     onLoadSuccess () {},


### PR DESCRIPTION
Setting crossOrigin='anonymous' on the Image before making the request causes the Image to fail to load in some circumstances<sup>1</sup> when the server does not include CORS headers on its response.  This was hard to track down, and therefore I suggest that we remove the default crossOrigin prop, meaning that users who wish to load CORS-enabled images in the ReactAvatarEditor will need to explicitly set it.  With this new behaviour, calls to getImage() and getImageScaledToCanvas() will fail when non-CORS enabled images are used, but the component will otherwise work as expected.  Conversely, with the current default of 'anonymous', the component fails to render, generating errors in the console that aren't linked to the component.

<sup>1</sup>: For me, the image fails to load in the ReactAvatarEditor when it's already been loaded elsewhere in an offscreen canvas - this occurred in Chrome, Firefox and Safari on OSX - I haven't gotten around to testing IE / Edge yet.