### PR TITLE
fix(componentDidMount): this.canvas could be null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -326,10 +326,13 @@ class AvatarEditor extends React.Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
-    const context = ReactDOM.findDOMNode(this.canvas).getContext('2d')
-    context.clearRect(0, 0, this.getDimensions().canvas.width, this.getDimensions().canvas.height)
-    this.paint(context)
-    this.paintImage(context, this.state.image, this.props.border)
+    const canvasNode = ReactDOM.findDOMNode(this.canvas);
+    if (this.canvas && canvasNode) {
+      const context = canvasNode.getContext('2d')
+      context.clearRect(0, 0, this.getDimensions().canvas.width, this.getDimensions().canvas.height)
+      this.paint(context)
+      this.paintImage(context, this.state.image, this.props.border)
+    }
 
     if (prevProps.image !== this.props.image ||
         prevProps.width !== this.props.width ||

--- a/src/index.js
+++ b/src/index.js
@@ -294,11 +294,14 @@ class AvatarEditor extends React.Component {
   }
 
   componentDidMount () {
-    const context = ReactDOM.findDOMNode(this.canvas).getContext('2d')
+    const canvasNode = ReactDOM.findDOMNode(this.canvas);
     if (this.props.image) {
       this.loadImage(this.props.image)
     }
-    this.paint(context)
+    if (this.canvas && canvasNode) {
+      const context = canvasNode.getContext('2d')
+      this.paint(context)
+    }
     if (document) {
       const nativeEvents = deviceEvents.native
       document.addEventListener(nativeEvents.move, this.handleMouseMove, false)


### PR DESCRIPTION
I used this great component pretty well.
But when I wanted to test my component with enzyme, an error occurred.
```
 FAIL  __tests__/Storyshots.test.js
  ● Console

    console.info node_modules/@storybook/react/dist/server/babel_config.js:67
      => Loading custom .babelrc

  ● Storyshots › Image › with text

    TypeError: Cannot read property 'getContext' of null
      
      at AvatarEditor.componentDidMount (node_modules/react-avatar-editor/dist/index.js:1:7532)
      at node_modules/react-test-renderer/lib/ReactCompositeComponent.js:265:25
      at measureLifeCyclePerf (node_modules/react-test-renderer/lib/ReactCompositeComponent.js:75:12)
      at node_modules/react-test-renderer/lib/ReactCompositeComponent.js:264:11
      at CallbackQueue.notifyAll (node_modules/react-test-renderer/lib/CallbackQueue.js:76:22)
      at ReactTestReconcileTransaction.close (node_modules/react-test-renderer/lib/ReactTestReconcileTransaction.js:36:26)
      at ReactTestReconcileTransaction.closeAll (node_modules/react-test-renderer/lib/Transaction.js:206:25)
      at ReactTestReconcileTransaction.perform (node_modules/react-test-renderer/lib/Transaction.js:153:16)
      at batchedMountComponentIntoNode (node_modules/react-test-renderer/lib/ReactTestMount.js:69:27)
      at ReactDefaultBatchingStrategyTransaction.perform (node_modules/react-test-renderer/lib/Transaction.js:140:20)
      at Object.batchedUpdates (node_modules/react-test-renderer/lib/ReactDefaultBatchingStrategy.js:62:26)
      at Object.batchedUpdates (node_modules/react-test-renderer/lib/ReactUpdates.js:97:27)
      at Object.render (node_modules/react-test-renderer/lib/ReactTestMount.js:125:18)
      at Object.<anonymous> (node_modules/@storybook/addon-storyshots/dist/index.js:120:56)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
      at process._tickCallback (internal/process/next_tick.js:103:7)
```

So I looked into the code, I believe the problem is here in [line 297](https://github.com/mosch/react-avatar-editor/blob/master/src/index.js#L297).
I tried to fix it with a fork and it works.
So I post this PR for you.