### PR TITLE
Adds ability to disable drop handling behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ export default MyEditor
 | position               | Object   | The x and y co-ordinates (in the range 0 to 1) of the center of the cropping area of the image.  Note that if you set this prop, you will need to keep it up to date via onPositionChange in order for panning to continue working.
 | rotate                 | Number   | The rotation degree of the image. You can use this to rotate image (e.g 90, 270 degrees).
 | crossOrigin            | String   | The value to use for the crossOrigin property of the image, if loaded from a non-data URL.  Valid values are `"anonymous"` and `"use-credentials"`.  See [this page](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for more information.
+| disableDrop            | Boolean  | Disables drop handling behavior (defaults to `false`)      
 | onDropFile(event)      | function | Invoked when user drops a file (or more) onto the canvas. Does not perform any further check.
 | onLoadFailure(event)   | function | Invoked when an image (whether passed by props or dropped) load fails.
 | onLoadSuccess(imgInfo) | function | Invoked when an image (whether passed by props or dropped) load succeeds.

--- a/src/index.js
+++ b/src/index.js
@@ -98,10 +98,13 @@ class AvatarEditor extends React.Component {
     onImageChange: PropTypes.func,
     onMouseUp: PropTypes.func,
     onMouseMove: PropTypes.func,
-    onPositionChange: PropTypes.func
+    onPositionChange: PropTypes.func,
+
+    disableDrop: PropTypes.bool
   }
 
   static defaultProps = {
+    disableDrop: false,
     scale: 1,
     rotate: 0,
     border: 25,
@@ -599,7 +602,7 @@ class AvatarEditor extends React.Component {
 
     attributes[deviceEvents.react.down] = this.handleMouseDown
     attributes[deviceEvents.react.drag] = this.handleDragOver
-    attributes[deviceEvents.react.drop] = this.handleDrop
+    if (!this.props.disableDrop) attributes[deviceEvents.react.drop] = this.handleDrop
     if (isTouchDevice) attributes[deviceEvents.react.mouseDown] = this.handleMouseDown
 
     return (


### PR DESCRIPTION
Hi @mosch, 

This PR allows toggling off the drop behavior. For my usecase, the parent element was already handling drop behavior and I was looking to pass the file directly into the editor. I'll have another PR soon on that functionality.

Thanks!