### PR TITLE
Fix image painting when rotate !== 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ class AvatarEditor extends React.Component {
     }
 
     // don't paint a border here, as it is the resulting image
-    this.paintImage(canvas.getContext('2d'), this.state.image, 0)
+    this.paintImage(canvas.getContext('2d'), this.state.image, 0, 1)
 
     return canvas
   }
@@ -309,13 +309,10 @@ class AvatarEditor extends React.Component {
 
   componentDidMount () {
     const context = ReactDOM.findDOMNode(this.canvas).getContext('2d')
-    context.save()
-    context.scale(pixelRatio, pixelRatio)
     if (this.props.image) {
       this.loadImage(this.props.image)
     }
     this.paint(context)
-    context.restore()
     if (document) {
       const nativeEvents = deviceEvents.native
       document.addEventListener(nativeEvents.move, this.handleMouseMove, false)
@@ -340,13 +337,11 @@ class AvatarEditor extends React.Component {
   }
 
   componentDidUpdate (prevProps, prevState) {
-    const context = ReactDOM.findDOMNode(this.canvas).getContext('2d')
-    context.save()
-    context.scale(pixelRatio, pixelRatio)
-    context.clearRect(0, 0, this.getDimensions().canvas.width, this.getDimensions().canvas.height)
+    const canvas = ReactDOM.findDOMNode(this.canvas)
+    const context = canvas.getContext('2d')
+    context.clearRect(0, 0, canvas.width, canvas.height)
     this.paint(context)
     this.paintImage(context, this.state.image, this.props.border)
-    context.restore()
 
     if (prevProps.image !== this.props.image ||
         prevProps.width !== this.props.width ||
@@ -401,7 +396,7 @@ class AvatarEditor extends React.Component {
     }
   }
 
-  paintImage (context, image, border) {
+  paintImage (context, image, border, scaleFactor = pixelRatio) {
     if (image.resource) {
       const position = this.calculatePosition(image, border)
 
@@ -414,6 +409,8 @@ class AvatarEditor extends React.Component {
       if (this.isVertical()) {
         context.translate((context.canvas.width - context.canvas.height) / 2, (context.canvas.height - context.canvas.width) / 2)
       }
+
+      context.scale(scaleFactor, scaleFactor)
 
       context.globalCompositeOperation = 'destination-over'
       context.drawImage(image.resource, position.x, position.y, position.width, position.height)
@@ -453,6 +450,7 @@ class AvatarEditor extends React.Component {
 
   paint (context) {
     context.save()
+    context.scale(pixelRatio, pixelRatio)
     context.translate(0, 0)
     context.fillStyle = 'rgba(' + this.props.color.slice(0, 4).join(',') + ')'
 


### PR DESCRIPTION
Previously the canvas was scaled before applying the rotation, but the transform origin did not take account of the scaling, which meant that the image was not rotated around its center, causing it to ping off somewhere else off-canvas.  Now, the scale factor is applied after the transform, so there's no need to account for it.

Fixes #183.