### PR TITLE
Add support for passing File in image prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,27 @@ export default MyEditor
 ```
 
 ## Props
-| Prop                   | Type     | Description
-| ---------------------- | -------- | ---------------
-| width                  | Number   | The total width of the editor
-| height                 | Number   | The total width of the editor
-| border                 | Number\|Number[]   | The cropping border. Image will be visible through the border, but cut off in the resulting image. Treated as horizonal and vertical borders when passed an array
-| borderRadius           | Number   | The cropping area border radius.
-| color                  | Number[] | The color of the cropping border, in the form: [red (0-255), green (0-255), blue (0-255), alpha (0.0-1.0)]
-| style                  | Object   | Styles for the canvas element
-| scale                  | Number   | The scale of the image. You can use this to add your own resizing slider.
-| position               | Object   | The x and y co-ordinates (in the range 0 to 1) of the center of the cropping area of the image.  Note that if you set this prop, you will need to keep it up to date via onPositionChange in order for panning to continue working.
-| rotate                 | Number   | The rotation degree of the image. You can use this to rotate image (e.g 90, 270 degrees).
-| crossOrigin            | String   | The value to use for the crossOrigin property of the image, if loaded from a non-data URL.  Valid values are `"anonymous"` and `"use-credentials"`.  See [this page](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for more information.
-| onDropFile(event)      | function | Invoked when user drops a file (or more) onto the canvas. Does not perform any further check.
-| onLoadFailure(event)   | function | Invoked when an image (whether passed by props or dropped) load fails.
-| onLoadSuccess(imgInfo) | function | Invoked when an image (whether passed by props or dropped) load succeeds.
-| onImageReady(event)    | function | Invoked when the image is painted on the canvas the first time
-| onMouseUp()            | function | Invoked when the user releases their mouse button after interacting with the editor.
-| onMouseMove()          | function | Invoked when the user hold and moving the image.
-| onImageChange()        | function | Invoked when the user changed the image. Not invoked on the first render, and invoked multiple times during drag, etc.
-| onPositionChange()     | function | Invoked when the user pans the editor to change the selected area of the image.  Passed a position object in the form `{ x: 0.5, y: 0.5 }` where x and y are the relative x and y coordinates of the center of the selected area.
+| Prop                   | Type             | Description
+| ---------------------- | ---------------- | ---------------
+| image                  | String\|File     | The URL of the image to use, or a File (e.g. from a file input).
+| width                  | Number           | The total width of the editor.
+| height                 | Number           | The total height of the editor.
+| border                 | Number\|Number[] | The cropping border. Image will be visible through the border, but cut off in the resulting image. Treated as horizontal and vertical borders when passed an array.
+| borderRadius           | Number           | The cropping area border radius.
+| color                  | Number[]         | The color of the cropping border, in the form: [red (0-255), green (0-255), blue (0-255), alpha (0.0-1.0)].
+| style                  | Object           | Styles for the canvas element.
+| scale                  | Number           | The scale of the image. You can use this to add your own resizing slider.
+| position               | Object           | The x and y co-ordinates (in the range 0 to 1) of the center of the cropping area of the image.  Note that if you set this prop, you will need to keep it up to date via onPositionChange in order for panning to continue working.
+| rotate                 | Number           | The rotation degree of the image. You can use this to rotate image (e.g 90, 270 degrees).
+| crossOrigin            | String           | The value to use for the crossOrigin property of the image, if loaded from a non-data URL.  Valid values are `"anonymous"` and `"use-credentials"`.  See [this page](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for more information.
+| onDropFile(event)      | function         | Invoked when user drops a file (or more) onto the canvas. Does not perform any further check.
+| onLoadFailure(event)   | function         | Invoked when an image (whether passed by props or dropped) load fails.
+| onLoadSuccess(imgInfo) | function         | Invoked when an image (whether passed by props or dropped) load succeeds.
+| onImageReady(event)    | function         | Invoked when the image is painted on the canvas the first time.
+| onMouseUp()            | function         | Invoked when the user releases their mouse button after interacting with the editor.
+| onMouseMove()          | function         | Invoked when the user hold and moving the image.
+| onImageChange()        | function         | Invoked when the user changed the image. Not invoked on the first render, and invoked multiple times during drag, etc.
+| onPositionChange()     | function         | Invoked when the user pans the editor to change the selected area of the image.  Passed a position object in the form `{ x: 0.5, y: 0.5 }` where x and y are the relative x and y coordinates of the center of the selected area.
 
 ## Accessing the resulting image
 

--- a/docs/App.jsx
+++ b/docs/App.jsx
@@ -13,6 +13,10 @@ class App extends React.Component {
     height: 200
   }
 
+  handleNewImage = (e) => {
+    this.setState({ image: e.target.files[0] })
+  };
+
   handleSave = (data) => {
     const img = this.editor.getImageScaledToCanvas().toDataURL()
     const rect = this.editor.getCroppingRect()
@@ -105,7 +109,14 @@ class App extends React.Component {
           onImageReady={this.logCallback.bind(this, 'onImageReady')}
           onImageLoad={this.logCallback.bind(this, 'onImageLoad')}
           onDropFile={this.logCallback.bind(this, 'onDropFile')}
-          image='avatar.jpg'
+          image={this.state.image || 'avatar.jpg'}
+        />
+        <br />
+        New File:
+        <input
+          name='newImage'
+          type='file'
+          onChange={this.handleNewImage}
         />
         <br />
         Zoom:

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   ],
   "standard": {
     "global": [
+      "File",
       "FileReader",
       "Image"
     ],

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,10 @@ class AvatarEditor extends React.Component {
   static propTypes = {
     scale: PropTypes.number,
     rotate: PropTypes.number,
-    image: PropTypes.string,
+    image: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(File)
+    ]),
     border: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.arrayOf(PropTypes.number)
@@ -299,12 +302,26 @@ class AvatarEditor extends React.Component {
     return !!str.match(regex)
   }
 
-  loadImage (imageURL) {
+  loadImage (image) {
+    if (image instanceof File) {
+      this.loadImageFile(image)
+    } else {
+      this.loadImageURL(image)
+    }
+  }
+
+  loadImageURL (imageURL) {
     const imageObj = new Image()
     imageObj.onload = this.handleImageReady.bind(this, imageObj)
     imageObj.onerror = this.props.onLoadFailure
     if (!this.isDataURL(imageURL) && this.props.crossOrigin) imageObj.crossOrigin = this.props.crossOrigin
     imageObj.src = imageURL
+  }
+
+  loadImageFile (imageFile) {
+    const reader = new FileReader()
+    reader.onload = (e) => this.loadImageURL(e.target.result)
+    reader.readAsDataURL(imageFile)
   }
 
   componentDidMount () {
@@ -569,10 +586,7 @@ class AvatarEditor extends React.Component {
 
     if (e.dataTransfer && e.dataTransfer.files.length) {
       this.props.onDropFile(e)
-      const reader = new FileReader()
-      const file = e.dataTransfer.files[0]
-      reader.onload = (e) => this.loadImage(e.target.result)
-      reader.readAsDataURL(file)
+      this.loadImageFile(e.dataTransfer.files[0])
     }
   }
 


### PR DESCRIPTION
* `image` prop can now contain a `File` or string.
* Add information about `image` prop to README (and a little bit of general cleanup of the props table).
* Add file chooser to demo to make it easy to test this functionality.