### PR TITLE
Pass event to the handler on mouse/touch move

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export default MyEditor
 | onLoadSuccess(imgInfo) | function         | Invoked when an image (whether passed by props or dropped) load succeeds.
 | onImageReady(event)    | function         | Invoked when the image is painted on the canvas the first time.
 | onMouseUp()            | function         | Invoked when the user releases their mouse button after interacting with the editor.
-| onMouseMove()          | function         | Invoked when the user hold and moving the image.
+| onMouseMove(event)     | function         | Invoked when the user hold and moving the image.
 | onImageChange()        | function         | Invoked when the user changed the image. Not invoked on the first render, and invoked multiple times during drag, etc.
 | onPositionChange()     | function         | Invoked when the user pans the editor to change the selected area of the image.  Passed a position object in the form `{ x: 0.5, y: 0.5 }` where x and y are the relative x and y coordinates of the center of the selected area.
 

--- a/src/index.js
+++ b/src/index.js
@@ -573,7 +573,7 @@ class AvatarEditor extends React.Component {
 
     this.setState(newState)
 
-    this.props.onMouseMove()
+    this.props.onMouseMove(e)
   }
 
   handleDragOver (e) {


### PR DESCRIPTION
It is possible that the parent element is also draggable, but if this is an image selection, parent handler should not be triggered. Passing event allows calling a `stopPropagation` function and make the parent handler not receive the event.

Thanks!