### PR TITLE
Use AvatarEditor from src instead of dist folder.

### DIFF
--- a/docs/App.jsx
+++ b/docs/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import ReactAvatarEditor from '../dist/index'
+import ReactAvatarEditor from '../src/index'
 
 class App extends React.Component {
   state = {


### PR DESCRIPTION
Usually for development we want to use the current sources from the `src` folder instead of the `dist`. Otherwise we'd need to run `yarn build` everytime before seeing changes.

@mtlewis you changed that recently, can you say what was the reason behind it? :)