### PR TITLE
Drop async/await for now until we get it sorted out.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "babel-plugin-external-helpers": "6.22.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-polyfill": "6.26.0",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "^6.24.1",
     "eslint": "4.18.2",

--- a/src/index.js
+++ b/src/index.js
@@ -404,17 +404,15 @@ class AvatarEditor extends React.Component {
     }
   }
 
-  async loadImage(image) {
-    let newImage
+  loadImage(image) {
     if (isFileAPISupported && image instanceof File) {
-      newImage = await loadImageFile(image)
+      loadImageFile(image).then(this.handleImageReady)
     } else if (typeof image === 'string') {
-      newImage = await loadImageURL(image, this.props.crossOrigin)
+      loadImageURL(image, this.props.crossOrigin).then(this.handleImageReady)
     }
-    this.handleImageReady(newImage)
   }
 
-  handleImageReady (image) {
+  handleImageReady = image => {
     const imageState = this.getInitialSize(image.width, image.height)
     imageState.resource = image
     imageState.x = 0.5

--- a/src/utils/load-image-file.js
+++ b/src/utils/load-image-file.js
@@ -4,7 +4,7 @@ import loadImageURL from './load-image-url'
 export default function loadImageFile(imageFile) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
-    reader.onload = async e => {
+    reader.onload = e => {
       try {
         const image = loadImageURL(e.target.result)
         resolve(image)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
 module.exports = {
-  entry: ['babel-polyfill', './docs/App.jsx'],
+  entry: './docs/App.jsx',
   output: {
     filename:
       process.env.NODE_ENV === 'production' ? 'docs/bundle.js' : 'bundle.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -802,14 +802,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
-
 babel-polyfill@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
@@ -1450,10 +1442,6 @@ core-js@^1.0.0:
 core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
-
-core-js@^2.5.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -4290,10 +4278,6 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz#257f41961ce44558b18f7814af48c17559f9faeb"
-
-regenerator-runtime@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
Because of the latest issues regarding `regeneratorRuntime` related to `babel-preset-env` we should drop `async`/`await` for now until we get that sorted out.