### PR TITLE
fix: handle uncaught error when load image fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -406,9 +406,13 @@ class AvatarEditor extends React.Component {
 
   loadImage(image) {
     if (isFileAPISupported && image instanceof File) {
-      loadImageFile(image).then(this.handleImageReady)
+      loadImageFile(image)
+        .then(this.handleImageReady)
+        .catch(this.props.onLoadFailure)
     } else if (typeof image === 'string') {
-      loadImageURL(image, this.props.crossOrigin).then(this.handleImageReady)
+      loadImageURL(image, this.props.crossOrigin)
+        .then(this.handleImageReady)
+        .catch(this.props.onLoadFailure)
     }
   }
 


### PR DESCRIPTION
-`image.onerror` resulted in an uncaught error in Promise

-`onLoadFailure` was never called in the code