### PR TITLE
#250 Disable touch-actions on avatar canvas

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -672,6 +672,7 @@ class AvatarEditor extends React.Component {
       width: dimensions.canvas.width,
       height: dimensions.canvas.height,
       cursor: this.state.drag ? 'grabbing' : 'grab',
+      touchAction: 'none',
     }
 
     const attributes = {


### PR DESCRIPTION
#250 

This is the recommended way to deal with Chrome having changed touch events to being "passive" by default and thus ignoring calls to `preventDefault()`.
This fixes the avatar panning being difficult in Chrome due to the browser's default touch handling kicking in (which scrolls the page instead).

See https://developers.google.com/web/updates/2017/01/scrolling-intervention#breakage_and_guidance 