### PR TITLE
fixes disableBoundaryChecks warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -664,6 +664,7 @@ class AvatarEditor extends React.Component {
       onMouseUp,
       onMouseMove,
       onPositionChange,
+      disableBoundaryChecks,
       ...rest
     } = this.props
 


### PR DESCRIPTION
Remove disableBoundaryChecks in default props since it'll be falsy by default