### PR TITLE
Stop double-scrolling on iOS Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,5 +93,8 @@
   },
   "eslintConfig": {
     "extends": "react-app"
+  },
+  "jest": {
+    "testURL": "http://localhost"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ class AvatarEditor extends React.Component {
       // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
       let passiveSupported = false;
       try {
-        let options = Object.defineProperty({}, "passive", {
+        const options = Object.defineProperty({}, "passive", {
           get: function() {
             passiveSupported = true;
           }

--- a/src/index.js
+++ b/src/index.js
@@ -174,19 +174,35 @@ class AvatarEditor extends React.Component {
     }
     this.paint(context)
     if (document) {
+      // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+      let passiveSupported = false;
+      try {
+        let options = Object.defineProperty({}, "passive", {
+          get: function() {
+            passiveSupported = true;
+          }
+        });
+
+        window.addEventListener("test", options, options);
+        window.removeEventListener("test", options, options);
+      } catch(err) {
+        passiveSupported = false;
+      }
+      const thirdArgument = passiveSupported ? { passive: false } : false;
+
       const nativeEvents = deviceEvents.native
-      document.addEventListener(nativeEvents.move, this.handleMouseMove, false)
-      document.addEventListener(nativeEvents.up, this.handleMouseUp, false)
+      document.addEventListener(nativeEvents.move, this.handleMouseMove, thirdArgument)
+      document.addEventListener(nativeEvents.up, this.handleMouseUp, thirdArgument)
       if (isTouchDevice) {
         document.addEventListener(
           nativeEvents.mouseMove,
           this.handleMouseMove,
-          false
+          thirdArgument
         )
         document.addEventListener(
           nativeEvents.mouseUp,
           this.handleMouseUp,
-          false
+          thirdArgument
         )
       }
     }
@@ -581,6 +597,8 @@ class AvatarEditor extends React.Component {
     if (this.state.drag === false) {
       return
     }
+
+    e.preventDefault();  // stop scrolling on iOS Safari
 
     const mousePositionX = e.targetTouches
       ? e.targetTouches[0].pageX

--- a/src/index.js
+++ b/src/index.js
@@ -180,7 +180,7 @@ class AvatarEditor extends React.Component {
         const options = Object.defineProperty({}, "passive", {
           get: function() {
             passiveSupported = true;
-          }
+          },
         });
 
         window.addEventListener("test", options, options);

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,24 @@ const isTouchDevice = !!(
 
 const isFileAPISupported = typeof File !== 'undefined'
 
+const isPassiveSupported = () => {
+  // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+  let passiveSupported = false;
+  try {
+    const options = Object.defineProperty({}, "passive", {
+      get: function() {
+        passiveSupported = true;
+      },
+    });
+
+    window.addEventListener("test", options, options);
+    window.removeEventListener("test", options, options);
+  } catch(err) {
+    passiveSupported = false;
+  }
+  return passiveSupported;
+}
+
 const draggableEvents = {
   touch: {
     react: {
@@ -174,20 +192,7 @@ class AvatarEditor extends React.Component {
     }
     this.paint(context)
     if (document) {
-      // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
-      let passiveSupported = false;
-      try {
-        const options = Object.defineProperty({}, "passive", {
-          get: function() {
-            passiveSupported = true;
-          },
-        });
-
-        window.addEventListener("test", options, options);
-        window.removeEventListener("test", options, options);
-      } catch(err) {
-        passiveSupported = false;
-      }
+      const passiveSupported = isPassiveSupported();
       const thirdArgument = passiveSupported ? { passive: false } : false;
 
       const nativeEvents = deviceEvents.native


### PR DESCRIPTION
This is related to https://github.com/mosch/react-avatar-editor/issues/250 ; the fix that worked for Chrome doesn't work for iOS.  This commit makes things the same on both mobile Chrome and Safari: when the user pans avatar editor, it doesn't also scroll the page.

This should also address https://github.com/mosch/react-avatar-editor/issues/258 (and thanks to karltaylor whose comment helped with this fix).

What was needed was a simple `evt.preventDefault()` inside mouseMove; however Safari will ignore this unless `{passive: false}` passed to addEventListener.  Because _that_ is not completely cross-browser compatible, it needed a feature test.

Also included a small Jest fix so the tests passed during development.  Manually tested that the scrolling works on both mobile Chrome and Safari (and also desktop Firefox, Chrome, and Safari).