### PR TITLE
Reset the image in state when empty image is passed as a prop to avoid repainting the old one in componentDidUpdate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -180,10 +180,7 @@ class AvatarEditor extends React.Component {
     drag: false,
     my: null,
     mx: null,
-    image: {
-      x: 0.5,
-      y: 0.5,
-    },
+    image: this.defaultEmptyImage,
   }
 
   componentDidMount() {
@@ -277,6 +274,11 @@ class AvatarEditor extends React.Component {
         )
       }
     }
+  }
+
+  defaultEmptyImage = {
+    x: 0.5,
+    y: 0.5,
   }
 
   isVertical() {
@@ -482,6 +484,9 @@ class AvatarEditor extends React.Component {
     const canvas = this.canvas
     const context = canvas.getContext('2d')
     context.clearRect(0, 0, canvas.width, canvas.height)
+    this.setState({
+      image: this.defaultEmptyImage,
+    })
   }
 
   paintImage(context, image, border, scaleFactor = pixelRatio) {

--- a/src/index.js
+++ b/src/index.js
@@ -120,6 +120,11 @@ const drawRoundedRect = (context, x, y, width, height, borderRadius) => {
   }
 }
 
+const defaultEmptyImage = {
+  x: 0.5,
+  y: 0.5,
+}
+
 class AvatarEditor extends React.Component {
   static propTypes = {
     scale: PropTypes.number,
@@ -180,7 +185,7 @@ class AvatarEditor extends React.Component {
     drag: false,
     my: null,
     mx: null,
-    image: this.defaultEmptyImage,
+    image: defaultEmptyImage,
   }
 
   componentDidMount() {
@@ -274,11 +279,6 @@ class AvatarEditor extends React.Component {
         )
       }
     }
-  }
-
-  defaultEmptyImage = {
-    x: 0.5,
-    y: 0.5,
   }
 
   isVertical() {
@@ -485,7 +485,7 @@ class AvatarEditor extends React.Component {
     const context = canvas.getContext('2d')
     context.clearRect(0, 0, canvas.width, canvas.height)
     this.setState({
-      image: this.defaultEmptyImage,
+      image: defaultEmptyImage,
     })
   }
 


### PR DESCRIPTION
 #249  
When passing an empty image (null, undefined, etc) in order to clear the canvas after you initially loaded an image the old image in the state is not cleared thus repainting the old one on the canvas we just cleared when componentDidUpdate fires.