### PR TITLE
(wip) Allow setting canvas dimensions instead of border

### DIFF
--- a/docs/App.jsx
+++ b/docs/App.jsx
@@ -14,6 +14,8 @@ class App extends React.Component {
     preview: null,
     width: 200,
     height: 200,
+    canvasWidth: 478,
+    canvasHeight: 270,
   }
 
   handleNewImage = e => {
@@ -109,7 +111,7 @@ class App extends React.Component {
           onDrop={this.handleDrop}
           disableClick
           multiple={false}
-          style={{ width: this.state.width, height: this.state.height, marginBottom:'35px' }}
+          style={{ width: this.state.canvasWidth, height: this.state.canvasHeight, marginBottom:'35px' }}
         >
           <div>
             <ReactAvatarEditor
@@ -117,6 +119,8 @@ class App extends React.Component {
               scale={parseFloat(this.state.scale)}
               width={this.state.width}
               height={this.state.height}
+              canvasWidth={this.state.canvasWidth}
+              canvasHeight={this.state.canvasHeight}
               position={this.state.position}
               onPositionChange={this.handlePositionChange}
               rotate={parseFloat(this.state.rotate)}

--- a/src/index.js
+++ b/src/index.js
@@ -159,6 +159,8 @@ class AvatarEditor extends React.Component {
     borderRadius: PropTypes.number,
     width: PropTypes.number,
     height: PropTypes.number,
+    canvasWidth: PropTypes.number,
+    canvasHeight: PropTypes.number,
     position: PropTypes.shape({
       x: PropTypes.number,
       y: PropTypes.number,
@@ -309,7 +311,19 @@ class AvatarEditor extends React.Component {
   }
 
   getBorders(border = this.props.border) {
-    return Array.isArray(border) ? border : [border, border]
+    const borders = Array.isArray(border) ? border : [border, border]
+
+    const { width, height, canvasWidth, canvasHeight } = this.props
+
+    if (canvasWidth) {
+      borders[0] = (canvasWidth - width) / 2
+    }
+
+    if (canvasHeight) {
+      borders[1] = (canvasHeight - height) / 2
+    }
+
+    return borders
   }
 
   getDimensions() {
@@ -317,17 +331,14 @@ class AvatarEditor extends React.Component {
 
     const canvas = {}
 
-    const [borderX, borderY] = this.getBorders(border)
-
-    const canvasWidth = width
-    const canvasHeight = height
+    const [borderX, borderY] = this.getBorders()
 
     if (this.isVertical()) {
-      canvas.width = canvasHeight
-      canvas.height = canvasWidth
+      canvas.width = height
+      canvas.height = width
     } else {
-      canvas.width = canvasWidth
-      canvas.height = canvasHeight
+      canvas.width = width
+      canvas.height = height
     }
 
     canvas.width += borderX * 2
@@ -713,6 +724,8 @@ class AvatarEditor extends React.Component {
       borderRadius,
       width,
       height,
+      canvasWidth,
+      canvasHeight,
       position,
       color,
       /* eslint-disable react/prop-types */


### PR DESCRIPTION
Playing around with options for setting canvas dimensions instead of border. There's _at least_ one thing that doesn't work in this branch - while the cropping UI looks right, the preview image is not correct, so something in the rendering code needs to be adjusted to support the canvas dimensions instead of the border. It also seems like this feature would be improved by the option to automatically zoom the image to the bounds of the canvas, rather than the bounds of the cropping rect. Will keep playing around with this, but I'm also happy for others to pick this up and take it forward!