### PR TITLE
Update Dropzone example

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ We recommend using [react-dropzone](https://github.com/react-dropzone/react-drop
 drag and drop support to anything really easy. Here is an example how to use it with react-avatar-editor:
 
 ```javascript
-import React, { Fragment } from 'react'
+import React from 'react'
 import AvatarEditor from 'react-avatar-editor'
 import Dropzone from 'react-dropzone'
 
@@ -146,15 +146,10 @@ class MyEditor extends React.Component {
         style={{ width: '250px', height: '250px' }}
       >
         {({ getRootProps, getInputProps }) => (
-          <Fragment>
-            <AvatarEditor
-              width={250}
-              height={250}
-              image={this.state.image}
-              {...getRootProps()}
-            />
+          <div {...getRootProps()}>
+            <AvatarEditor width={250} height={250} image={this.state.image} />
             <input {...getInputProps()} />
-          </Fragment>
+          </div>
         )}
       </Dropzone>
     )

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you want the image sized in the dimensions of the canvas you can use `getImag
 import React from 'react'
 import AvatarEditor from 'react-avatar-editor'
 
-const MyEditor extends React.Component {
+class MyEditor extends React.Component {
   onClickSave = () => {
     if (this.editor) {
       // This returns a HTMLCanvasElement, it can be made into a data URL or a blob,
@@ -124,18 +124,34 @@ We recommend using [react-dropzone](https://github.com/react-dropzone/react-drop
 drag and drop support to anything really easy. Here is an example how to use it with react-avatar-editor:
 
 ```javascript
+import React from 'react'
+import AvatarEditor from 'react-avatar-editor'
+import Dropzone from 'react-dropzone'
+
 class MyEditor extends React.Component {
+  state = {
+    image: 'http://example.com/initialimage.jpg',
+  }
+
   handleDrop = dropped => {
     this.setState({ image: dropped[0] })
   }
+
   render() {
     return (
       <Dropzone
         onDrop={this.handleDrop}
-        disableClick
+        noClick
         style={{ width: '250px', height: '250px' }}
       >
-        <ReactAvatarEditor width={250} height={250} image={this.state.image} />
+        {({ getRootProps }) => (
+          <AvatarEditor
+            width={250}
+            height={250}
+            image={this.state.image}
+            {...getRootProps()}
+          />
+        )}
       </Dropzone>
     )
   }

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ We recommend using [react-dropzone](https://github.com/react-dropzone/react-drop
 drag and drop support to anything really easy. Here is an example how to use it with react-avatar-editor:
 
 ```javascript
-import React from 'react'
+import React, { Fragment } from 'react'
 import AvatarEditor from 'react-avatar-editor'
 import Dropzone from 'react-dropzone'
 
@@ -146,13 +146,15 @@ class MyEditor extends React.Component {
         style={{ width: '250px', height: '250px' }}
       >
         {({ getRootProps, getInputProps }) => (
-          <AvatarEditor
-            width={250}
-            height={250}
-            image={this.state.image}
-            {...getRootProps()}
-          />
-          <input {...getInputProps()} />
+          <Fragment>
+            <AvatarEditor
+              width={250}
+              height={250}
+              image={this.state.image}
+              {...getRootProps()}
+            />
+            <input {...getInputProps()} />
+          </Fragment>
         )}
       </Dropzone>
     )

--- a/README.md
+++ b/README.md
@@ -142,15 +142,17 @@ class MyEditor extends React.Component {
       <Dropzone
         onDrop={this.handleDrop}
         noClick
+        noKeyboard
         style={{ width: '250px', height: '250px' }}
       >
-        {({ getRootProps }) => (
+        {({ getRootProps, getInputProps }) => (
           <AvatarEditor
             width={250}
             height={250}
             image={this.state.image}
             {...getRootProps()}
           />
+          <input {...getInputProps()} />
         )}
       </Dropzone>
     )


### PR DESCRIPTION
Hello,

Thanks a lot for this super useful component! It's been a breeze to setup and use :).

This PR updates the example on Dropzone to reflect the changes to the `react-dropzone` API. Notably, they are now using a render prop and the current example will fail on proptypes checking.

Hope that's useful. Let me know if any changes are required.

Cheers,
Thibaut