### PR TITLE
prevent setState loop when image prop value is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,7 +251,7 @@ class AvatarEditor extends React.Component {
       this.props.height !== prevProps.height
     ) {
       this.loadImage(this.props.image)
-    } else if (!this.props.image) {
+    } else if (!this.props.image && prevState.image !== defaultEmptyImage) {
       this.clearImage()
     }
 


### PR DESCRIPTION
Hi! First, thank you for this package -- very useful! 

I just upgraded to the latest 12.0.0-beta release and I'm no longer able to load the component due to max update depth exceeded errors. I looked at the latest commits and found the issue:
```
componentDidUpdate(prevProps, prevState) {
  if (...) {...
  } else if (!this.props.image) {
    this.clearImage()
  }
}


clearImage = () => {
  ...
  this.setState({
    image: defaultEmptyImage,
  })
}
```
If the image prop value is null/undefined (which may be the case if you are waiting on an async call to load a dataUrl or to do some sort of check on upload), the setState() in `clearImage` is going to trigger a `componentDidUpdate`, which will again call `clearImage -> setState()`, and so on in an infinite loop.

This PR addresses the issue by checking to make sure that the image state hasn't already been set to the default empty image value. As far as I can tell this should be a safe check since the only method setting the defaultEmptyImage state is `clearImage`.