### PR TITLE
add prop canvasBackgroundColor for setting canvas background

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,7 @@ class AvatarEditor extends React.Component {
       y: PropTypes.number,
     }),
     color: PropTypes.arrayOf(PropTypes.number),
+    canvasBackgroundColor: PropTypes.arrayOf(PropTypes.number),
     crossOrigin: PropTypes.oneOf(['', 'anonymous', 'use-credentials']),
 
     onLoadFailure: PropTypes.func,
@@ -185,6 +186,7 @@ class AvatarEditor extends React.Component {
     width: 200,
     height: 200,
     color: [0, 0, 0, 0.5],
+    canvasBackgroundColor: [0, 0, 0, 1],
     onLoadFailure() {},
     onLoadSuccess() {},
     onImageReady() {},
@@ -401,6 +403,12 @@ class AvatarEditor extends React.Component {
 
     // don't paint a border here, as it is the resulting image
     this.paintImage(canvas.getContext('2d'), this.state.image, 0, 1)
+
+    // optionally set the background color of canvas when "zoomed out" for an image
+    canvas.getContext('2d').globalCompositeOperation = 'destination-over'
+    canvas.getContext('2d').fillStyle =
+      'rgba(' + this.props.canvasBackgroundColor.slice(0, 4).join(',') + ')'
+    canvas.getContext('2d').fillRect(0, 0, canvas.width, canvas.height)
 
     return canvas
   }


### PR DESCRIPTION
Fixes #282 

Primarily comes into play when you have extra margin around the image and save as a JPEG.

Thanks to @afilp for his code snippet (which works).  

Defaults to white with opacity of 1, let me know if it should be black like the color prop or start with opacity of 0 , I'm happy to modify the pull request if anyone has suggestions.  The assumption is that more people will be displaying it on a white background vs a black one.  It also uses the same format ([R, G, B, A] number array) as the color prop.

Edit: I misspoke -- defaults to black with opacity of 1 :)  Was looking at a different branch of mine.