### PR TITLE
paint whole canvas background instead of image only

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -366,12 +366,7 @@ class AvatarEditor extends React.Component {
 
     if (image.backgroundColor) {
       context.fillStyle = image.backgroundColor
-      context.fillRect(
-        -cropRect.x,
-        -cropRect.y,
-        image.resource.width,
-        image.resource.height,
-      )
+      context.fillRect(0, 0, canvas.width, canvas.height)
     }
 
     context.drawImage(image.resource, -cropRect.x, -cropRect.y)
@@ -541,12 +536,7 @@ class AvatarEditor extends React.Component {
 
       if (image.backgroundColor) {
         context.fillStyle = image.backgroundColor
-        context.fillRect(
-          position.x,
-          position.y,
-          position.width,
-          position.height,
-        )
+        context.fillRect(0, 0, context.canvas.width, context.canvas.height)
       }
 
       context.restore()


### PR DESCRIPTION
Changes the behaviour for `backgroundColor` option. It previously painted only the area behind the image. It does now paint the whole canvas.
This change is particularly interesting when allowing scale <1.
I don't really see why background was limited to the image bounds, so maybe it breaks a use case I don't know about.