### PR TITLE
Adding optional 'Rule of Three' grid.

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -56,6 +56,34 @@ const drawRoundedRect = (
   }
 }
 
+// Draws a "Rule of Three" grid on the canvas.
+const drawGrid = (
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  gridColor: string,
+) => {
+  context.fillStyle = gridColor;
+  const thirdsX = width / 3;
+  const thirdsY = height / 3;
+
+  // vertical bars
+  context.fillRect(x, y, 1, height);
+  context.fillRect(thirdsX + x, y, 1, height);
+  context.fillRect((thirdsX * 2) + x, y, 1, height);
+  context.fillRect((thirdsX * 3) + x, y, 1, height);
+  context.fillRect((thirdsX * 4) + x, y, 1, height);
+
+  // horizontal bars
+  context.fillRect(x, y, width, 1);
+  context.fillRect(x, thirdsY + y, width, 1);
+  context.fillRect(x, (thirdsY * 2) + y, width, 1);
+  context.fillRect(x, (thirdsY * 3) + y, width, 1);
+  context.fillRect(x, (thirdsY * 4) + y, width, 1);
+}
+
 const defaultEmptyImage = {
   x: 0.5,
   y: 0.5,
@@ -126,6 +154,8 @@ class AvatarEditor extends React.Component<PropsWithDefaults, State> {
     width: 200,
     height: 200,
     color: [0, 0, 0, 0.5],
+    showGrid: false,
+    gridColor: '#666',
     disableBoundaryChecks: false,
     disableHiDPIScaling: false,
     disableCanvasRotation: true,
@@ -558,6 +588,16 @@ class AvatarEditor extends React.Component<PropsWithDefaults, State> {
     context.rect(width, 0, -width, height) // outer rect, drawn "counterclockwise"
     context.fill('evenodd')
 
+    if (this.props.showGrid) {
+      drawGrid(
+          context,
+          borderSizeX,
+          borderSizeY,
+          width - borderSizeX * 2,
+          height - borderSizeY * 2,
+          this.props.gridColor,
+      )
+    }
     context.restore()
   }
 


### PR DESCRIPTION
This commit includes an optional feature to turn on a 'rule of three' grid with configurable color value.

- I was thinking of allowing number | string for color to account for hex
- The grid doesn't are about radius. In my opinion, it is acceptable in design, but I understand the desire to clip the grid as the radius changes.