### PR TITLE
Fix floating point calculations

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -479,10 +479,10 @@ class AvatarEditor extends React.Component<PropsWithDefaults, State> {
 
     if (canvasRatio > imageRatio) {
       newHeight = dimensions.height
-      newWidth = width * (newHeight / height)
+      newWidth = Math.round(width * (newHeight / height))
     } else {
       newWidth = dimensions.width
-      newHeight = height * (newWidth / width)
+      newHeight = Math.round(height * (newWidth / width))
     }
 
     return {


### PR DESCRIPTION
Fix floating point errors when computing width and height by roudning to the nearest integer value. Fixes #392 

Some calculations will return with a non integer value:
<img width="175" alt="Screenshot 2025-03-25 at 9 04 57 AM" src="https://github.com/user-attachments/assets/69bb110b-073a-47d6-b5d0-6fe431819095" />
