### PR TITLE
Fix props types

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -94,8 +94,6 @@ const defaultEmptyImage = {
   y: 0.5,
 }
 
-type BorderType = [number, number] | number
-
 interface ImageState {
   x: number
   y: number
@@ -109,7 +107,7 @@ export interface Props {
   height: number
   style?: CSSProperties
   image?: string | File
-  border?: BorderType
+  border?: number
   position?: Position
   scale?: number
   rotate?: number
@@ -128,6 +126,8 @@ export interface Props {
   disableHiDPIScaling?: boolean
   disableCanvasRotation?: boolean
   borderColor?: [number, number, number, number?]
+  showGrid?: boolean
+  gridColor?: string
 }
 
 export interface Position {
@@ -142,8 +142,8 @@ interface State {
   image: ImageState
 }
 
-type PropsWithDefaults = typeof AvatarEditor.defaultProps &
-  Omit<Props, keyof typeof AvatarEditor.defaultProps>
+type PropsWithDefaults = Omit<Props, keyof typeof AvatarEditor.defaultProps> &
+  Required<Pick<Props, keyof typeof AvatarEditor.defaultProps>>
 
 class AvatarEditor extends React.Component<PropsWithDefaults, State> {
   private canvas = React.createRef<HTMLCanvasElement>()
@@ -165,7 +165,7 @@ class AvatarEditor extends React.Component<PropsWithDefaults, State> {
     disableBoundaryChecks: false,
     disableHiDPIScaling: false,
     disableCanvasRotation: true,
-  }
+  } satisfies Props
 
   state: State = {
     drag: false,


### PR DESCRIPTION
Hi! While trying to use the latest beta version, I noticed a mismatch between types coming from `Props` interface and the actual component props. The mismatch is mainly about `border` and `color`. 

The issue comes from the `PropsWithDefaults` type, which overrides the `Props` interface types with ones inferred from `defaultProps`. 

This PR makes `Props` the source, while `defaultProps` is only used to mark some as required. 